### PR TITLE
Fixing machine readable coordinate bug

### DIFF
--- a/planetmapper/common.py
+++ b/planetmapper/common.py
@@ -1,3 +1,3 @@
-__version__ = '1.1.0'
+__version__ = '1.1.1'
 __author__ = 'Oliver King'
 __url__ = 'https://github.com/ortk95/planetmapper'

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -832,7 +832,7 @@ class GUI:
         ra, dec = coords['ra'], coords['dec']
         parts = [
             f'"xy": [{x:{fmt}}, {y:{fmt}}]',
-            f'"radec": [{ra:{fmt_radec}}, {dec:{fmt_radec}}]]',
+            f'"radec": [{ra:{fmt_radec}}, {dec:{fmt_radec}}]',
         ]
 
         try:
@@ -1375,7 +1375,7 @@ class OpenObservation(Popup):
     def make_widget(self) -> None:
         if self.first_run:
             self.window = tk.Tk()
-            self.window.title('planetmapper')
+            self.window.title('PlanetMapper')
             self.gui.configure_style(self.window)
             geometry = self.gui.DEFAULT_GEOMETRY
         else:


### PR DESCRIPTION
`radec` part of machine readable string had an extra ']' which would prevent this string being actually machine readable.

### Checklist before merging to `main`
- [x] Run unit tests
- [x] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`