### PR TITLE
Fixing timezone bug

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -109,7 +109,7 @@ class SpiceBase:
             aware and set to the UTC timezone.
         """
         dtm: datetime.datetime = astropy.time.Time(mjd, format='mjd').datetime
-        return dtm.astimezone(datetime.timezone.utc)
+        return dtm.replace(tzinfo=datetime.timezone.utc)
 
     def speed_of_light(self) -> float:
         """

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -169,7 +169,7 @@ class Body(SpiceBase):
             utc = datetime.datetime.now(datetime.timezone.utc)
         if isinstance(utc, datetime.datetime):
             # convert input datetime to UTC, then to a string compatible with spice
-            utc = utc.astimezone(datetime.timezone.utc)
+            utc = utc.replace(tzinfo=datetime.timezone.utc)
             utc = utc.strftime(self._DEFAULT_DTM_FORMAT_STRING)
         self.utc = utc
 


### PR DESCRIPTION
We want to use datetime.replace rather than .astimezone to avoid offsets for non-utc times

### Checklist before merging to `main`
- [x] Run unit tests
- [ ] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`