### PR TITLE
Correctly load HST-style date/time header values

### DIFF
--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -210,6 +210,11 @@ class Observation(BodyXY):
                 kw['utc'] = mjd
             except:
                 pass
+            if 'utc' not in kw:
+                try:
+                    kw['utc'] = header['DATE-OBS'] + ' ' + header['TIME-OBS']
+                except KeyError:
+                    pass
             _try_get_header_value(
                 kw,
                 header,

--- a/scratchpad.py
+++ b/scratchpad.py
@@ -5,10 +5,13 @@ import planetmapper
 import matplotlib.pyplot as plt
 import numpy as np
 import importlib
+importlib.reload(planetmapper)
 importlib.reload(planetmapper.gui)
+importlib.reload(planetmapper.observation)
 
 p = '/Users/ortk1/Desktop/iew608inq_drz.fits'
 observation = planetmapper.Observation(p, aberration_correction='CN', target='uranus')
+observation.plot_wireframe_radec()
 observation.run_gui()
 # observation.disc_from_wcs(True, False)
 # observation.plot_wireframe_xy()


### PR DESCRIPTION
Combines `DATE-OBS` and `TIME-OBS` header values correctly

Closes #136

### Checklist before merging to `main`
- [ ] Run unit tests
- [ ] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`