### PR TITLE
Changing default aberration correction to `CN`

### DIFF
--- a/docs/user_interface.rst
+++ b/docs/user_interface.rst
@@ -15,7 +15,7 @@ It is also possible to start a user interface directly using :func:`planetmapper
 
 
 Fitting an observation
-===============================
+======================
 To start, type `planetmapper` into a command line and press enter. This will open a window where you can choose a file to open:
  
 .. image:: images/gui_open.png

--- a/docs/user_interface.rst
+++ b/docs/user_interface.rst
@@ -80,7 +80,7 @@ This simple example shows how you could use :func:`planetmapper.Observation.run_
 
     for path in sorted(glob.glob('data/*.fits')):
         # Running from Python allows you to customise SPICE settings like the aberration correction
-        observation = planetmapper.Observation(path, aberration_correction='CN')
+        observation = planetmapper.Observation(path, aberration_correction='CN+S')
 
         # Run some custom setup
         observation.add_other_bodies_of_interest('Io', 'Europa', 'Ganymede', 'Callisto')

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -44,10 +44,10 @@ class Body(SpiceBase):
             Date (MJD) of the observation. Alternatively, if `utc` is `None` (the
             default), then the current time is used.
         observer: Name of observing body. Defaults to `'EARTH'`.
-        observer_frame: Observer reference frame. Defaults to `'J2000'`,
-        illumination_source: Illumination source. Defaults to `'SUN'`.
         aberration_correction: Aberration correction used to correct light travel time
             in SPICE.
+        observer_frame: Observer reference frame. Defaults to `'J2000'`,
+        illumination_source: Illumination source. Defaults to `'SUN'`.
         subpoint_method: Method used to calculate the sub-observer point in SPICE.
         surface_method: Method used to calculate surface intercepts in SPICE.
         **kwargs: Additional arguments are passed to :class:`SpiceBase`.
@@ -59,9 +59,9 @@ class Body(SpiceBase):
         utc: str | datetime.datetime | float | None = None,
         observer: str | int = 'EARTH',
         *,
+        aberration_correction: str = 'CN',
         observer_frame: str = 'J2000',
         illumination_source: str = 'SUN',
-        aberration_correction: str = 'CN+S',
         subpoint_method: str = 'INTERCEPT/ELLIPSOID',
         surface_method: str = 'ELLIPSOID',
         **kwargs,

--- a/planetmapper/common.py
+++ b/planetmapper/common.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 __author__ = 'Oliver King'
 __url__ = 'https://github.com/ortk95/planetmapper'

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -298,10 +298,10 @@ class Observation(BodyXY):
             assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
 
         # a1, a2 = wcs.pixel_to_world_values(1, 0)
-        b1, b2 = wcs.pixel_to_world_values(0, 1)
+        b1, b2 = wcs.pixel_to_world_values(0, self.r_eq)
         c1, c2 = wcs.pixel_to_world_values(0, 0)
 
-        s = np.sqrt((b1 - c1) ** 2 + (b2 - c2) ** 2)
+        s = np.sqrt((b1 - c1) ** 2 + (b2 - c2) ** 2)/self.r_eq
 
         rotation = np.rad2deg(np.arctan2(b1 - c1, b2 - c2))
         arcsec_per_px = s * 60 * 60  # s = degrees/px

--- a/scratchpad.py
+++ b/scratchpad.py
@@ -3,7 +3,32 @@
 """Script for testing stuff during development"""
 import planetmapper
 import matplotlib.pyplot as plt
+import astropy.wcs
+import numpy as np
+
+# gui = planetmapper.gui.GUI()
+# gui.run()
 
 p = '/Users/ortk1/Desktop/iew608inq_drz.fits'
-observation = planetmapper.Observation(p, aberration_correction='CN', target='uranus')
-observation.run_gui()
+p = '/Users/ortk1/Dropbox/PhD/data/GBdata/muse/preview/ADP.2019-10-10T21:55:21.853.fits'
+observation = planetmapper.Observation(p, target='io', aberration_correction='CN')
+observation.plot_wireframe_radec()
+plt.show()
+
+header = observation.header
+# wcs = observation._get_wcs_from_header()
+wcs = astropy.wcs.WCS(header).celestial
+
+ra, dec = observation.limb_radec()
+
+img = np.nanmean(observation.data, axis=0)
+plt.imshow(img, origin='lower', cmap='Greys_r')
+x, y = np.array(wcs.world_to_pixel_values(np.array([ra, dec]).T)).T
+plt.plot(x, y)
+
+observation.disc_from_wcs()
+x, y = observation.limb_xy()
+plt.plot(x, y)
+
+
+plt.show()

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -7,7 +7,9 @@ from numpy import array, nan
 
 class TestBody(unittest.TestCase):
     def setUp(self):
-        self.obj = planetmapper.Body('jupiter', '2000-01-01')
+        self.obj = planetmapper.Body(
+            'jupiter', '2000-01-01', aberration_correction='CN+S'
+        )
 
     def test_setup(self):
         self.assertEqual(self.obj.target_body_id, 599)
@@ -61,7 +63,9 @@ class TestBody(unittest.TestCase):
 
 class TestObservation(unittest.TestCase):
     def setUp(self):
-        self.obj = planetmapper.BodyXY('saturn', '2001-02-03', nx=4, ny=6)
+        self.obj = planetmapper.BodyXY(
+            'saturn', '2001-02-03', nx=4, ny=6, aberration_correction='CN+S'
+        )
         self.obj.set_x0(2)
         self.obj.set_y0(4.5)
         self.obj.set_r0(3.14)


### PR DESCRIPTION
Provides significantly better consistency with the WCS information in e.g. HST, JWST, ESO headers

### Checklist before merging to `main`
- [x] Run unit tests
- [x] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`