### PR TITLE
Don't use memmap when reading FITS data

### DIFF
--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -149,7 +149,7 @@ class Observation(BodyXY):
         assert self.path is not None
         # TODO generally do this better
         # TODO add check data is a cube
-        with fits.open(self.path) as hdul:
+        with fits.open(self.path, memmap=False) as hdul:
             for idx, hdu in enumerate(hdul):
                 if hdu.data is not None:
                     data = hdu.data


### PR DESCRIPTION
`memmap=True` can cause issues by opening too many file handles if processing large numbers of observations

### Checklist before creating new release
- [ ] Run unit tests
- [ ] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`