### PR TITLE
Only produce pixel backplane for valid pixels

### DIFF
--- a/scratchpad.py
+++ b/scratchpad.py
@@ -8,7 +8,11 @@ import numpy as np
 import spiceypy as spice
 
 p = '/Users/ortk1/Dropbox/PhD/data/jwst/Uranus_2023jan08/lon2/stage3/d1/Level3_ch4-short_s3d.fits'
+p = '/Users/ortk1/Dropbox/PhD/data/jwst/saturn/SATURN-75N/stage6_flat/d1_fringe_nav/Level3_ch1-short_s3d_nav.fits'
 body = planetmapper.Observation(p)
-body.plot_wireframe_radec(show=True, add_axis_labels=False, dms_ticks=False)
-body.plot_wireframe_km(show=True, aspect_adjustable='box', add_title=False)
-body.plot_wireframe_xy(show=True)
+body.plot_backplane_map('pixel-x')
+plt.show()
+
+img = body.data[0]
+mapped = body.map_img(img, interpolation='cubic')
+body.imshow_map(mapped)


### PR DESCRIPTION
Previously, mapped backplane pixel coordinates were extrapolated beyond the bounds of the image (e.g. a 30x30 image could have a backplane map with pixel coordinate values >30). This was (a) misleading and (b) broke some of the mapping interpolation, so the new version checks pixel coordinates are valid before adding them to the map.

### Checklist before creating new release
- [ ] Run unit tests
- [ ] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`