### PR TITLE
Improve NaN propagation when mapping

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -984,12 +984,23 @@ class BodyXY(Body):
                 if math.isnan(x):
                     continue
                 y = y_map[a, b]  # y should never be nan when x is not nan
-                if propagate_nan and nans[int(np.round(y)), int(np.round(x))]:
+                if propagate_nan and self._should_propagate_nan_to_map(x, y, nans):
                     continue
                 projected[a, b] = interpolator(y, x)
         else:
             raise ValueError(f'Unknown interpolation method {interpolation!r}')
         return projected
+
+    def _should_propagate_nan_to_map(
+        self, x: float, y: float, nans: np.ndarray
+    ) -> bool:
+        # Test if any of the four surrounding integer pixels in the image are NaN
+        return (
+            nans[math.floor(y), math.floor(x)]
+            or nans[math.floor(y), math.ceil(x)]
+            or nans[math.ceil(y), math.floor(x)]
+            or nans[math.ceil(y), math.ceil(x)]
+        )
 
     def _xy_in_image_frame(self, x: float, y: float) -> bool:
         return (-0.5 < x < self._nx - 0.5) and (-0.5 < y < self._ny - 0.5)

--- a/scratchpad.py
+++ b/scratchpad.py
@@ -3,16 +3,30 @@
 """Script for testing stuff during development"""
 import planetmapper
 import matplotlib.pyplot as plt
+import numpy as np
 
-p = '/Users/ortk1/Dropbox/PhD/data/jwst/Uranus_2023jan08/lon2/stage3/d1/Level3_ch4-short_s3d.fits'
-p = '/Users/ortk1/Dropbox/PhD/data/jwst/saturn/SATURN-75N/stage6_flat/d1_fringe_nav/Level3_ch1-short_s3d_nav.fits'
-body = planetmapper.Observation(p)
+try:
+    observation: planetmapper.Observation = observation  #  type: ignore
+except NameError:
+    p = '/Users/ortk1/Dropbox/science/jwst_data/MIRI_IFU/Saturn_2022nov13/SATURN-15N/stage3/d2_fringe_nav/Level3_ch1-short_s3d_nav.fits'
+    observation = planetmapper.Observation(p)
+
 # body.plot_backplane_map('pixel-x')
 # plt.show()
 
-img = body.data[0]
-mapped = body.map_img(img, interpolation='cubic')
-body.imshow_map(mapped)
+img = observation.data[187]
+img[img.shape[0]//2, img.shape[1]//2] = np.nan
+mapped = observation.map_img(img, interpolation='linear', degree_interval=1)
+
+fig, ax = plt.subplots()
+observation.imshow_map(mapped, ax=ax,
+                                   vmin=np.nanpercentile(img, 1),
+            vmax=np.nanpercentile(img, 99),
+)
+
+ax.set_xlim(np.nanmax(observation.get_lon_img()), np.nanmin(observation.get_lon_img()))
+ax.set_ylim(np.nanmin(observation.get_lat_img()), np.nanmax(observation.get_lat_img()))
+
 plt.show()
 
 # mapped = body.map_img(img, interpolation='linear', mask_nan=False)


### PR DESCRIPTION
When mapping with spline interpolation, map pixels are automatically set to NaN if any of the four surrounding pixels are NaN

### Checklist before creating new release
- [ ] Run unit tests
- [ ] Increase version number
- [ ] Run spell check on documentation
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`