### PR TITLE
Add workaround for XQuartz font bug causing planetmapper GUI to crash when running over some SSH connections

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -36,4 +36,21 @@ This is likely to be due to an issue with your SPICE kernels or settings, possib
 - Make sure you are using the correct observation time - times in PlanetMapper default to UTC, so make sure there are no time zone conversions needed.
 - Make sure you have the latest version of any SPICE kernels, especially for any observers like HST or JWST which have have locations which are difficult to predict accurately.
 - Make sure you are using the correct aberration correction.
-- If you are using WCS information saved in the FITS header to automatically set the disc position, note that telescope pointing information (i.e. the WCS information) is never pefect. For example, due to the errors in guide star tracking, JWST pointing is only accurate to ~0.5".
+- If you are using WCS information saved in the FITS header to automatically set the disc position, note that telescope pointing information (i.e. the WCS information) is never perfect. For example, due to the errors in guide star tracking, JWST pointing is only accurate to ~0.5".
+
+
+PlanetMapper crashes when running graphical user interface over SSH
+====================================================================
+Recent versions of XQuartz `appear to have a font handling bug <https://github.com/XQuartz/XQuartz/issues/216>`_ which can cause PlanetMapper to crash when running the user interface over an SSH connection using X11 forwarding: ::
+
+    X Error of failed request:  BadValue (integer parameter out of range for operation)
+      Major opcode of failed request:  45 (X_OpenFont)
+      Value in failed request:  0x60027c
+      Serial number of failed request:  3572
+      Current serial number in output stream:  3573
+
+As a temporary workaround, you can set the `PLANETMAPPER_USE_X11_FONT_BUGFIX` environment variable to `true` on your remote machine before running PlanetMapper if you experience this issue. You can add the following line to to your `.bash_profile` file to automatically set this environment variable: ::
+
+    export PLANETMAPPER_USE_X11_FONT_BUGFIX=true
+
+This tells the PlanetMapper user interface to replace certain characters with ASCII equivalents (e.g. `↑` is replaced with `^`) which seems to prevent the use of the fonts which cause XQuartz to crash. Note that this will make the user interface slightly more ugly, but should not affect functionality. If you are still having issues after trying this workaround, you can `add a comment to the GitHub issue <https://github.com/ortk95/planetmapper/issues/145>`_.

--- a/planetmapper/common.py
+++ b/planetmapper/common.py
@@ -1,3 +1,3 @@
-__version__ = '1.6.3'
+__version__ = '1.6.4'
 __author__ = 'Oliver King'
 __url__ = 'https://github.com/ortk95/planetmapper'


### PR DESCRIPTION
### Checklist before creating new release
- [x] Increase version number
- [ ] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`