### PR TITLE
Use `exclude_lines` for `[tool.coverage.report]` to work correctly with Coveralls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ include = ["planetmapper/*.py"]
 omit = ["planetmapper/gui.py"]
 
 [tool.coverage.report]
-exclude_also = [
+exclude_lines = [
+    "pragma: no cover",
     "^\\s*\\.\\.\\.$", # "..." lines (typing overloads etc.)
     "^if TYPE_CHECKING:$",
     ]


### PR DESCRIPTION
Looks like coveralls python doesn't support `exclude_also` yet

### Checklist before creating new release
- [ ] Increase version number
- [ ] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`