### PR TITLE
Add `numpy<2.0` to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 astropy
 matplotlib
-numpy
+numpy<2.0
 Pillow
 spiceypy
 scipy

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     install_requires=[
         'astropy',
         'matplotlib',
-        'numpy',
+        'numpy<2.0',
         'Pillow',
         'spiceypy',
         'scipy',


### PR DESCRIPTION
The NumPy API may change in 2.0 (https://github.com/numpy/numpy/issues/24300), so ensure we are only using NumPy 1.x until we have properly tested NumPy 2.0. 

### Pull request checklist
- [x] Add a clear description of the change
- [ ] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py`
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.