### PR TITLE
Allow full formatting of map wireframes to be consistent with image wireframes

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1668,8 +1668,6 @@ class BodyXY(Body):
         ax: Axes | None = None,
         show: bool = False,
         **kwargs
-        # plot_kwargs: dict | None = None,
-        # **map_kwargs: Unpack[_MapKwargs],
     ) -> Axes:
         """
         Plot a map of backplane values on the target body.

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1119,8 +1119,7 @@ class BodyXY(Body):
         indicate_prime_meridian: bool = True,
         aspect_adjustable: Literal['box', 'datalim'] = 'box',
         formatting: dict[_WireframeComponent, dict[str, Any]] | None = None,
-        common_formatting: dict[str, Any] | None = None,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_and_formatting_kwargs,
     ) -> Axes:
         """
         Plot wireframe (e.g. gridlines) of the map projection of the observation. See
@@ -1141,8 +1140,14 @@ class BodyXY(Body):
         if ax is None:
             ax = cast(Axes, plt.gca())
 
+        map_kwargs = {}
+        # pylint: disable-next=no-member
+        for k in set(_MapKwargs.__optional_keys__) | set(_MapKwargs.__required_keys__):
+            if k in map_and_formatting_kwargs:
+                map_kwargs[k] = map_and_formatting_kwargs.pop(k)
+
         kwargs = self._get_wireframe_kw(
-            common_formatting=common_formatting, formatting=formatting
+            common_formatting=map_and_formatting_kwargs, formatting=formatting
         )
         _, _, _, _, transformer, map_kw_used = self.generate_map_coordinates(
             **map_kwargs

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1140,14 +1140,10 @@ class BodyXY(Body):
         if ax is None:
             ax = cast(Axes, plt.gca())
 
-        map_kwargs = {}
-        # pylint: disable-next=no-member
-        for k in set(_MapKwargs.__optional_keys__) | set(_MapKwargs.__required_keys__):
-            if k in map_and_formatting_kwargs:
-                map_kwargs[k] = map_and_formatting_kwargs.pop(k)
+        map_kwargs, common_formatting = _extract_map_kwargs_from_dict(map_and_formatting_kwargs)
 
         kwargs = self._get_wireframe_kw(
-            common_formatting=map_and_formatting_kwargs, formatting=formatting
+            common_formatting=common_formatting, formatting=formatting
         )
         _, _, _, _, transformer, map_kw_used = self.generate_map_coordinates(
             **map_kwargs
@@ -1282,11 +1278,7 @@ class BodyXY(Body):
         if ax is None:
             fig, ax = plt.subplots()
 
-        map_kwargs = {}
-        # pylint: disable-next=no-member
-        for k in set(_MapKwargs.__optional_keys__) | set(_MapKwargs.__required_keys__):
-            if k in kwargs:
-                map_kwargs[k] = kwargs.pop(k)
+        map_kwargs, kwargs = _extract_map_kwargs(kwargs)
 
         _, _, xx, yy, _, _ = self.generate_map_coordinates(**map_kwargs)
         h = ax.pcolormesh(xx, yy, map_img, **kwargs)
@@ -3186,3 +3178,27 @@ def _make_backplane_documentation_str() -> str:
     msg.append('')
 
     return '\n'.join(msg)
+
+
+def _extract_map_kwargs_from_dict(kwargs_dict) -> tuple[_MapKwargs, dict[str, Any]]:
+    """
+    Split a dictionary of keyword arguments into a dictionary of map kwargs and a
+    dictionary of other kwargs.
+
+    Args:
+        kwargs_dict: Dictionary of keyword arguments.
+    
+    Returns:
+        Tuple containing a dictionary of map kwargs and a dictionary of other kwargs.
+    """
+    # XXX add test
+    # pylint: disable-next=no-member
+    map_keys = set(_MapKwargs.__optional_keys__) | set(_MapKwargs.__required_keys__)
+    map_kwargs = _MapKwargs()
+    other_kwargs = {}
+    for k, v in kwargs_dict.items():
+        if k in map_keys:
+            map_kwargs[k] = v
+        else:
+            other_kwargs[k] = v
+    return map_kwargs, other_kwargs

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1663,11 +1663,7 @@ class BodyXY(Body):
         return ax
 
     def plot_backplane_map(
-        self,
-        name: str,
-        ax: Axes | None = None,
-        show: bool = False,
-        **kwargs
+        self, name: str, ax: Axes | None = None, show: bool = False, **kwargs
     ) -> Axes:
         """
         Plot a map of backplane values on the target body.
@@ -3201,7 +3197,6 @@ def _extract_map_kwargs_from_dict(kwargs_dict) -> tuple[_MapKwargs, dict[str, An
     Returns:
         Tuple containing a dictionary of map kwargs and a dictionary of other kwargs.
     """
-    # XXX add test
     # pylint: disable-next=no-member
     map_keys = set(_MapKwargs.__optional_keys__) | set(_MapKwargs.__required_keys__)
     map_kwargs = _MapKwargs()

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -1331,6 +1331,37 @@ class TestBodyXY(unittest.TestCase):
         self.assertEqual(len(ax.get_children()), 27)
         plt.close('all')
 
+        fig, ax = plt.subplots()
+        self.body.plot_backplane_map(
+            ' emission ',
+            degree_interval=90,
+            ax=ax,
+            cmap='Blues',
+            wireframe_kwargs=dict(color='r', zorder=2, alpha=0.5),
+        )
+        self.assertEqual(len(ax.get_lines()), 16)
+        self.assertEqual(len(ax.get_images()), 0)
+        self.assertEqual(len(ax.get_children()), 27)
+        plt.close(fig)
+
+        # back compatibility
+        fig, ax = plt.subplots()
+        self.body.plot_backplane_map(
+            ' emission ',
+            degree_interval=90,
+            ax=ax,
+            plot_kwargs=dict(
+                cmap='Blues',
+                wireframe_kwargs=dict(color='r', zorder=2, alpha=0.5),
+            ),
+        )
+        self.assertEqual(len(ax.get_lines()), 16)
+        self.assertEqual(len(ax.get_images()), 0)
+        self.assertEqual(len(ax.get_children()), 27)
+        plt.close(fig)
+
+        plt.close('all')
+
     def test_plot_map(self):
         fig, ax = plt.subplots()
         h = self.body.plot_map(np.ones((180, 360)), ax=ax)

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -44,9 +44,20 @@ class TestFunctions(unittest.TestCase):
                 {'projection': 'orthographic', 'a': 1, 'b': 2, 'xlim': (0, 1)},
                 ({'projection': 'orthographic', 'xlim': (0, 1)}, {'a': 1, 'b': 2}),
             ),
-                        (
-                {'projection': 'orthographic', 'color':'r', 'alpha':0.5, 'xlim': (0, 1)},
-                ({'projection': 'orthographic', 'xlim': (0, 1)}, { 'color':'r', 'alpha':0.5, }),
+            (
+                {
+                    'projection': 'orthographic',
+                    'color': 'r',
+                    'alpha': 0.5,
+                    'xlim': (0, 1),
+                },
+                (
+                    {'projection': 'orthographic', 'xlim': (0, 1)},
+                    {
+                        'color': 'r',
+                        'alpha': 0.5,
+                    },
+                ),
             ),
         ]
         for a, b in pairs:

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -660,6 +660,35 @@ class TestBodyXY(unittest.TestCase):
         fig, ax = plt.subplots()
         self.body.plot_map_wireframe(
             ax=ax,
+            projection='azimuthal equal area',
+            lat=-90,
+            label_poles=False,
+            grid_interval=45,
+            color='r',
+        )
+        self.assertEqual(len(ax.get_lines()), 20)
+        self.assertEqual(len(ax.get_images()), 0)
+        self.assertEqual(len(ax.get_children()), 30)
+        plt.close(fig)
+
+        # backwards compatibility
+        fig, ax = plt.subplots()
+        self.body.plot_map_wireframe(
+            ax=ax,
+            projection='azimuthal equal area',
+            lat=-90,
+            label_poles=False,
+            grid_interval=45,
+            common_formatting=dict(color='r'),
+        )
+        self.assertEqual(len(ax.get_lines()), 20)
+        self.assertEqual(len(ax.get_images()), 0)
+        self.assertEqual(len(ax.get_children()), 30)
+        plt.close(fig)
+
+        fig, ax = plt.subplots()
+        self.body.plot_map_wireframe(
+            ax=ax,
             projection='manual',
             lon_coords=np.linspace(-180, 180, 5),
             lat_coords=np.linspace(0, 90, 3),

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -21,6 +21,40 @@ class TestFunctions(unittest.TestCase):
             planetmapper.body_xy._make_backplane_documentation_str(), str
         )
 
+    def test_extract_map_kwargs_from_dict(self):
+        pairs: list[tuple[dict, tuple[dict, dict]]] = [
+            (
+                {},
+                ({}, {}),
+            ),
+            (
+                {'a': 1},
+                ({}, {'a': 1}),
+            ),
+            ({'projection': 'orthographic'}, ({'projection': 'orthographic'}, {})),
+            (
+                {'projection': 'orthographic', 'a': 1},
+                ({'projection': 'orthographic'}, {'a': 1}),
+            ),
+            (
+                {'projection': 'orthographic', 'a': 1, 'b': 2},
+                ({'projection': 'orthographic'}, {'a': 1, 'b': 2}),
+            ),
+            (
+                {'projection': 'orthographic', 'a': 1, 'b': 2, 'xlim': (0, 1)},
+                ({'projection': 'orthographic', 'xlim': (0, 1)}, {'a': 1, 'b': 2}),
+            ),
+                        (
+                {'projection': 'orthographic', 'color':'r', 'alpha':0.5, 'xlim': (0, 1)},
+                ({'projection': 'orthographic', 'xlim': (0, 1)}, { 'color':'r', 'alpha':0.5, }),
+            ),
+        ]
+        for a, b in pairs:
+            with self.subTest(a=a, b=b):
+                self.assertEqual(
+                    planetmapper.body_xy._extract_map_kwargs_from_dict(a), b
+                )
+
 
 class TestBodyXY(unittest.TestCase):
     def setUp(self):

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -574,6 +574,10 @@ class TestBodyXY(unittest.TestCase):
         self.assertEqual(len(ax.get_children()), 26)
         plt.close('all')
 
+        fig, ax = plt.subplots()
+        self.body.plot_map_wireframe(ax=ax, color='r', zorder=2, alpha=0.5)
+        plt.close(fig)
+
         uranus = BodyXY('uranus', utc='2000-01-01', sz=5)  # Uranus is +ve E
         ax = uranus.plot_map_wireframe(ax=ax)
         self.assertEqual(ax.get_xlim(), (0, 360))
@@ -1345,6 +1349,14 @@ class TestBodyXY(unittest.TestCase):
         self.assertEqual(len(ax.get_lines()), 0)
         self.assertEqual(len(ax.get_images()), 0)
         self.assertEqual(len(ax.get_children()), 11)
+        plt.close(fig)
+
+        fig, ax = plt.subplots()
+        self.body.plot_map(
+            np.ones((180, 360)),
+            ax=ax,
+            wireframe_kwargs=dict(color='r', zorder=2, alpha=0.5),
+        )
         plt.close(fig)
 
         self.body.imshow_map(np.ones((180, 360)))


### PR DESCRIPTION
### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.