### PR TITLE
Auto update matplotlib transforms when calling `matplotlib_xy2radec_transform` and `matplotlib_radec2xy_transform`

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -912,6 +912,7 @@ class BodyXY(Body):
             self._mpl_transform_xy2radec = (
                 self._get_matplotlib_xy2radec_transform_radians() + transform_deg2rad
             )
+        self.update_transform()  # https://github.com/ortk95/planetmapper/issues/310
         transform = self._mpl_transform_xy2radec
         if ax:
             transform = transform + ax.transData
@@ -925,6 +926,7 @@ class BodyXY(Body):
             self._mpl_transform_radec2xy = (
                 transform_rad2deg + self._get_matplotlib_radec2xy_transform_radians()
             )  # type: ignore
+        self.update_transform()  # https://github.com/ortk95/planetmapper/issues/310
         transform = self._mpl_transform_radec2xy
         if ax:
             transform = transform + ax.transData


### PR DESCRIPTION
Fixes #310

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.