### PR TITLE
Allow passing a file path when calling from CLI

### DIFF
--- a/planetmapper/__init__.py
+++ b/planetmapper/__init__.py
@@ -107,6 +107,8 @@ If you use PlanetMapper in your research, please :ref:`cite the following paper
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 """
+import sys
+
 from . import base, data_loader, gui, kernel_downloader, utils
 from .base import SpiceBase, get_kernel_path, set_kernel_path
 from .basic_body import BasicBody
@@ -136,4 +138,4 @@ __all__ = [
 def main():
     """:meta private:"""
     # pylint: disable-next=protected-access
-    gui._main()
+    gui._main(sys.argv[1:])

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -129,6 +129,7 @@ def _main(*args):
     if args:
         try:
             gui.set_observation(Observation(args[0]))
+        # pylint: disable-next=bare-except
         except Exception as e:
             print(f'Error loading observation: {e}')
             sys.exit(1)

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -1,6 +1,7 @@
 # pylint: disable=attribute-defined-outside-init,protected-access
 import math
 import os
+import sys
 import tkinter as tk
 import tkinter.colorchooser
 import tkinter.filedialog
@@ -126,7 +127,11 @@ def _main(*args):
         print('*** Using X11 font bugfix ***')
     gui = GUI()
     if args:
-        gui.set_observation(Observation(args[0]))
+        try:
+            gui.set_observation(Observation(args[0]))
+        except Exception as e:
+            print(f'Error loading observation: {e}')
+            sys.exit(1)
     gui.run()
 
 

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -129,7 +129,7 @@ def _main(*args):
     if args:
         try:
             gui.set_observation(Observation(args[0]))
-        # pylint: disable-next=bare-except
+        # pylint: disable-next=broad-exception-caught
         except Exception as e:
             print(f'Error loading observation: {e}')
             sys.exit(1)


### PR DESCRIPTION
#91

Can now pass a single filepath to directly open that file in the PlanetMapper GUI `$ planetmapper /path/to/file.fits`. This was partially implemented before, but the code was never actually callable. Also added simple error catching in this process.

### Pull request checklist
- [ ] Add a clear description of the change
- [ ] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py`
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.