### PR TITLE
Improve wireframe plots for targets near RA=0°

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -68,3 +68,8 @@ This is most likely to occur when using :func:`planetmapper.Body.plot_wireframe_
 To fix this, you can use the :func:`planetmapper.Body.plot_wireframe_angular`, which by default uses a coordinate system centred on the target body, which minimises any distortion. The origin of the `angular` coordinate system can also be customised to be any point in the sky, for example, using `body.plot_wireframe_angular(origin_ra=0, origin_dec=90)` may be useful for plotting observations in the sky around the north celestial pole.
 
 Plots may also appear distorted if using :func:`planetmapper.Body.plot_wireframe_angular` with a a custom origin that is a large distance from the target body.
+
+
+RA/Dec wireframe plots appear split into two halves
+===================================================
+If the target body is near RA=0°, the wireframe plot may appear to be split into two halves, due to part of the body having RA values near 0° and part having RA values near 360°. This can be fixed by using `body.plot_wireframe_radec(use_shifted_meridian=True)`, which will plot the wireframe with RA coordinates between -180° and 180°, rather than the default of 0° to 360°.

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -72,4 +72,4 @@ Plots may also appear distorted if using :func:`planetmapper.Body.plot_wireframe
 
 RA/Dec wireframe plots appear split into two halves
 ===================================================
-If the target body is near RA=0°, the wireframe plot may appear to be split into two halves, due to part of the body having RA values near 0° and part having RA values near 360°. This can be fixed by using `body.plot_wireframe_radec(use_shifted_meridian=True)`, which will plot the wireframe with RA coordinates between -180° and 180°, rather than the default of 0° to 360°.
+If the target body is near RA=0°, the `wireframe plot may appear to be split into two halves <https://github.com/ortk95/planetmapper/issues/326#issuecomment-1934275816>`__, due to part of the body having RA values near 0° and part having RA values near 360°. This can be fixed by using `body.plot_wireframe_radec(use_shifted_meridian=True)`, which will plot the wireframe with RA coordinates between -180° and 180°, rather than the default of 0° to 360°.

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2391,7 +2391,7 @@ class Body(BodyBase):
         dms_ticks: bool = True,
         add_axis_labels: bool = True,
         aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
-        use_shifted_meridian: bool = False,  # XXX rename
+        use_shifted_meridian: bool = False,
         show: bool = False,
         **wireframe_kwargs: Unpack[_WireframeKwargs],
     ) -> Axes:

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2492,7 +2492,7 @@ class Body(BodyBase):
 
             :func:`plot_wireframe_angular` can be used as an alternative to
             :func:`plot_wireframe_radec` to plot the wireframe without distortion from
-            the choice of coordinte system. By default, the `angular` coordinate system
+            the choice of coordinate system. By default, the `angular` coordinate system
             is centred on the target body, which minimises any distortion, but the
             origin and rotation of the `angular` coordinates can also be customised as
             needed (e.g. to align it with an instrument's field of view).

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2268,6 +2268,7 @@ class Body(BodyBase):
         *,
         coordinate_func: Callable[[float, float], tuple[float, float]],
         transform: matplotlib.transforms.Transform | None,
+        aspect_adjustable: Literal['box', 'datalim'] | None,
         ax: Axes | None = None,
         label_poles: bool = True,
         add_title: bool = True,
@@ -2379,6 +2380,8 @@ class Body(BodyBase):
 
         if add_title:
             ax.set_title(self.get_description(multiline=True))
+        if aspect_adjustable is not None:
+            ax.set_aspect(1, adjustable=aspect_adjustable)
         return ax
 
     def plot_wireframe_radec(
@@ -2387,7 +2390,7 @@ class Body(BodyBase):
         *,
         dms_ticks: bool = True,
         add_axis_labels: bool = True,
-        aspect_adjustable: Literal['box', 'datalim'] = 'datalim',
+        aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         show: bool = False,
         **wireframe_kwargs: Unpack[_WireframeKwargs],
     ) -> Axes:
@@ -2480,7 +2483,9 @@ class Body(BodyBase):
             indicate_prime_meridian: Toggle indicating the prime meridian with a solid
                 line.
             aspect_adjustable: Set `adjustable` parameter when setting the aspect ratio.
-                Passed to :func:`matplotlib.axes.Axes.set_aspect`.
+                Passed to :func:`matplotlib.axes.Axes.set_aspect`. Set to None to skip
+                setting the aspect ratio (generally this is only recommended if you're
+                setting the aspect ratio yourself).
             dms_ticks: Toggle between showing ticks as degrees, minutes and seconds
                 (e.g. 12°34′56″) or decimal degrees (e.g. 12.582). This argument is only
                 applicable for :func:`plot_wireframe_radec`.
@@ -2516,6 +2521,7 @@ class Body(BodyBase):
         ax = self._plot_wireframe(
             coordinate_func=lambda ra, dec: (ra, dec),
             transform=None,
+            aspect_adjustable=None,
             ax=ax,
             **wireframe_kwargs,
         )
@@ -2537,7 +2543,7 @@ class Body(BodyBase):
         ax: Axes | None = None,
         *,
         add_axis_labels: bool = True,
-        aspect_adjustable: Literal['box', 'datalim'] = 'datalim',
+        aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         show: bool = False,
         **wireframe_kwargs: Unpack[_WireframeKwargs],
     ) -> Axes:
@@ -2551,6 +2557,7 @@ class Body(BodyBase):
         ax = self._plot_wireframe(
             coordinate_func=self.radec2km,
             transform=None,
+            aspect_adjustable=aspect_adjustable,
             ax=ax,
             **wireframe_kwargs,
         )
@@ -2558,7 +2565,6 @@ class Body(BodyBase):
             ax.set_xlabel('Projected distance (km)')
             ax.set_ylabel('Projected distance (km)')
             ax.ticklabel_format(style='sci', scilimits=(-3, 3))
-        ax.set_aspect(1, adjustable=aspect_adjustable)
 
         if show:
             plt.show()
@@ -2572,7 +2578,7 @@ class Body(BodyBase):
         origin_dec: float | None = None,
         coordinate_rotation: float = 0.0,
         add_axis_labels: bool = True,
-        aspect_adjustable: Literal['box', 'datalim'] = 'datalim',
+        aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         show: bool = False,
         **wireframe_kwargs: Unpack[_WireframeKwargs],
     ) -> Axes:
@@ -2608,13 +2614,13 @@ class Body(BodyBase):
                 coordinate_rotation=coordinate_rotation,
             ),
             transform=None,
+            aspect_adjustable=aspect_adjustable,
             ax=ax,
             **wireframe_kwargs,
         )
         if add_axis_labels:
             ax.set_xlabel('Angular distance (arcsec)')
             ax.set_ylabel('Angular distance (arcsec)')
-        ax.set_aspect(1, adjustable=aspect_adjustable)
 
         if show:
             plt.show()

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2400,7 +2400,6 @@ class Body(BodyBase):
         Add NaNs into arrays when RA coords wraparound between 0 & 360. Useful for
         preprocessing arrays before plotting.
         """
-        # XXX test
         ra_out = []
         dec_out = []
         ra_prev = np.nan

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2533,9 +2533,7 @@ class Body(BodyBase):
         """
         # TODO maybe add automated warning at high declinations and for ra wraparound
         # TODO maybe fix plot() for ra wraparound by inserting NaNs into arrays
-
-        # XXX test wraparound
-        # XXX add wraparound to issues documentation
+        # TODO maybe add some fixed upper xlim/ylim for ra/dec plots
 
         if use_shifted_meridian:
             coordinate_func = lambda ra, dec: ((ra + 180.0) % 360.0 - 180.0, dec)

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1185,6 +1185,7 @@ class BodyXY(Body):
         ax = self._plot_wireframe(
             coordinate_func=self.radec2angular,
             transform=self._get_matplotlib_angular_fixed2xy_transform(),
+            aspect_adjustable=aspect_adjustable,
             ax=ax,
             **wireframe_kwargs,
         )
@@ -1195,7 +1196,6 @@ class BodyXY(Body):
         if add_axis_labels:
             ax.set_xlabel('x (pixels)')
             ax.set_ylabel('y (pixels)')
-        ax.set_aspect(1, adjustable=aspect_adjustable)
 
         if show:
             plt.show()

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1168,7 +1168,7 @@ class BodyXY(Body):
         ax: Axes | None = None,
         *,
         add_axis_labels: bool = True,
-        aspect_adjustable: Literal['box', 'datalim'] = 'box',
+        aspect_adjustable: Literal['box', 'datalim'] | None = 'box',
         show: bool = False,
         **wireframe_kwargs: Unpack[_WireframeKwargs],
     ) -> Axes:

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1212,7 +1212,7 @@ class BodyXY(Body):
         grid_lat_limit: float = 90,
         indicate_equator: bool = True,
         indicate_prime_meridian: bool = True,
-        aspect_adjustable: Literal['box', 'datalim'] = 'box',
+        aspect_adjustable: Literal['box', 'datalim'] | None = 'box',
         formatting: dict[_WireframeComponent, dict[str, Any]] | None = None,
         **map_and_formatting_kwargs,
     ) -> Axes:
@@ -1249,7 +1249,8 @@ class BodyXY(Body):
         )
         projection = map_kw_used['projection']
 
-        ax.set_aspect(1, adjustable=aspect_adjustable)
+        if aspect_adjustable is not None:
+            ax.set_aspect(1, adjustable=aspect_adjustable)
 
         lon_ticks = np.arange(0, 360.0001, grid_interval)
         lat_ticks = np.arange(-90, 90.0001, grid_interval)

--- a/planetmapper/utils.py
+++ b/planetmapper/utils.py
@@ -17,7 +17,7 @@ def format_radec_axes(
     dec: float,
     dms_ticks: bool = True,
     add_axis_labels: bool = True,
-    aspect_adjustable: Literal['box', 'datalim'] = 'datalim',
+    aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
 ) -> None:
     """
     Format an axis to display RA/Dec coordinates nicely.
@@ -29,12 +29,15 @@ def format_radec_axes(
             (e.g. 12°34′56″) or decimal degrees (e.g. 12.582).
         add_axis_labels: Add axis labels.
         aspect_adjustable: Set `adjustable` parameter when setting the aspect ratio.
-            Passed to :func:`matplotlib.axes.Axes.set_aspect`.
+            Passed to :func:`matplotlib.axes.Axes.set_aspect`. Set to None to skip
+            setting the aspect ratio (generally this is only recommended if you're
+            setting the aspect ratio yourself).
     """
     if add_axis_labels:
         ax.set_xlabel('Right Ascension')
         ax.set_ylabel('Declination')
-    ax.set_aspect(1 / np.cos(np.deg2rad(dec)), adjustable=aspect_adjustable)
+    if aspect_adjustable is not None:
+        ax.set_aspect(1 / np.cos(np.deg2rad(dec)), adjustable=aspect_adjustable)
     if not ax.xaxis_inverted():
         ax.invert_xaxis()
     if dms_ticks:

--- a/planetmapper/utils.py
+++ b/planetmapper/utils.py
@@ -70,9 +70,9 @@ class DMSFormatter(matplotlib.ticker.FuncFormatter):
     def _format(self, dd, pos):
         d, m, s = decimal_degrees_to_dms(dd)
         out = []
-        if 'd' not in self.skip_parts or m == 0 and s == 0:
+        if 'd' not in self.skip_parts or (m == 0 and s == 0):
             out.append(f'{d}°')
-        if 'm' not in self.skip_parts or s == 0:
+        if 'm' not in self.skip_parts or ('d' in self.skip_parts and s == 0):
             out.append(f'{m:02.0f}′')
         if 's' not in self.skip_parts:
             out.append(f'{s:{self.fmt_s}}″')

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1457,6 +1457,25 @@ class TestBody(common_testing.BaseTestCase):
         mock_show.assert_called_once()
         mock_show.reset_mock()
 
+        # Test radec wraparound
+        jupiter_from_amalthea = planetmapper.Body(
+            'jupiter', '2005-01-01', observer='amalthea'
+        )
+
+        fig, ax = plt.subplots()
+        jupiter_from_amalthea.plot_wireframe_radec(ax)
+        xlim = ax.get_xlim()
+        self.assertTrue(400 > xlim[0] > 350)
+        self.assertTrue(10 > xlim[1] > -60)
+        plt.close(fig)
+
+        fig, ax = plt.subplots()
+        jupiter_from_amalthea.plot_wireframe_radec(ax, use_shifted_meridian=True)
+        xlim = ax.get_xlim()
+        self.assertTrue(60 > xlim[0] > 10)
+        self.assertTrue(-10 > xlim[1] > -60)
+        plt.close(fig)
+
     def test_get_local_affine_transform_matrix(self):
         tests: list[
             tuple[

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1415,8 +1415,8 @@ class TestBody(common_testing.BaseTestCase):
             with self.subTest(ra=ra_in, dec=dec_in):
                 self.assertArraysEqual(
                     self.body._add_nans_for_radec_array_wraparounds(ra_in, dec_in),
-                    (ra_expected, dec_expected),                    equal_nan=True,
-
+                    (ra_expected, dec_expected),
+                    equal_nan=True,
                 )
 
         ras = [1, 1, 0, 270, 0, 270.1, 0, 44.9, 0, 45, 0, 45.1]

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -632,6 +632,16 @@ class TestBodyXY(common_testing.BaseTestCase):
         self.body.plot_map_wireframe(ax=ax, color='r', zorder=2, alpha=0.5)
         plt.close(fig)
 
+        fig, ax = plt.subplots()
+        self.body.plot_map_wireframe(ax=ax)
+        self.assertEqual(ax.get_aspect(), 1)
+        plt.close(fig)
+
+        fig, ax = plt.subplots()
+        self.body.plot_map_wireframe(ax=ax, aspect_adjustable=None)
+        self.assertEqual(ax.get_aspect(), 'auto')
+        plt.close(fig)
+
         uranus = BodyXY('uranus', utc='2000-01-01', sz=5)  # Uranus is +ve E
         ax = uranus.plot_map_wireframe(ax=ax)
         self.assertEqual(ax.get_xlim(), (0, 360))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,12 @@ class TestUtils(common_testing.BaseTestCase):
         plt.close(fig)
 
         fig, ax = plt.subplots()
+        utils.format_radec_axes(ax, 45, aspect_adjustable=None)
+        self.assertEqual(ax.get_aspect(), 'auto')
+        self.assertTrue(ax.xaxis_inverted())
+        plt.close(fig)
+
+        fig, ax = plt.subplots()
         ax.invert_xaxis()
         utils.format_radec_axes(
             ax, 0, dms_ticks=False, add_axis_labels=False, aspect_adjustable='box'


### PR DESCRIPTION
Closes #326.

Added:
- New option, `body.plot_wireframe_radec(use_shifted_meridian=True)`, to allow plotting RA/Dec wireframes with RA values between -180 and 180 (rather than the default of 0 and 360)
- Improved wireframe plots when a body is located on both sides so that plotted lines shouldn't cover the whole plot (see https://github.com/ortk95/planetmapper/issues/326#issuecomment-1934275816)

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.