### PR TITLE
Make `TypedDict` classes used to type hint keyword arguments publicly available

### DIFF
--- a/planetmapper/__init__.py
+++ b/planetmapper/__init__.py
@@ -123,8 +123,14 @@ If you use PlanetMapper in your research, please :ref:`cite the following paper
 from . import base, data_loader, gui, kernel_downloader, utils
 from .base import SpiceBase, get_kernel_path, set_kernel_path
 from .basic_body import BasicBody
-from .body import DEFAULT_WIREFRAME_FORMATTING, Body
-from .body_xy import Backplane, BodyXY
+from .body import (
+    DEFAULT_WIREFRAME_FORMATTING,
+    AngularCoordinateKwargs,
+    Body,
+    WireframeComponent,
+    WireframeKwargs,
+)
+from .body_xy import Backplane, BodyXY, MapKwargs
 from .common import __author__, __description__, __license__, __url__, __version__
 from .observation import Observation
 
@@ -137,10 +143,14 @@ __all__ = [
     'BodyXY',
     'Observation',
     'BasicBody',
+    'AngularCoordinateKwargs',
+    'WireframeKwargs',
+    'WireframeComponent',
+    'DEFAULT_WIREFRAME_FORMATTING',
+    'MapKwargs',
     'base',
     'gui',
     'utils',
     'kernel_downloader',
     'data_loader',
-    'DEFAULT_WIREFRAME_FORMATTING',
 ]

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -31,7 +31,7 @@ from . import data_loader, utils
 from .base import BodyBase, Numeric, _cache_stable_result
 from .basic_body import BasicBody
 
-_WireframeComponent = Literal[
+WireframeComponent = Literal[
     'all',
     'grid',
     'equator',
@@ -49,16 +49,28 @@ _WireframeComponent = Literal[
     'hidden_other_body_of_interest_label',
     'map_boundary',
 ]
+"""
+Literal type containing the names of all possible wireframe components.
+"""
+_WireframeComponent = WireframeComponent  # keep for backward compatibility
 
 
-class _WireframeKwargs(TypedDict, total=False):
+class WireframeKwargs(TypedDict, total=False):
+    """
+    Class to help type hint keyword arguments of wireframe plotting functions. The
+    `color`, `alpha` and `zorder` parameters are a non-exhaustive list of commonly used
+    formatting parameters which are passed to matplotlib functions.
+
+    See :func:`Body.plot_wireframe_radec` for more details.
+    """
+
     label_poles: bool
     add_title: bool
     grid_interval: float
     grid_lat_limit: float
     indicate_equator: bool
     indicate_prime_meridian: bool
-    formatting: dict[_WireframeComponent, dict[str, Any]] | None
+    formatting: dict[WireframeComponent, dict[str, Any]] | None
 
     # Hints for common formatting parameters to make type checking/autocomplete happy
     color: str | tuple[float, float, float]
@@ -66,7 +78,9 @@ class _WireframeKwargs(TypedDict, total=False):
     zorder: float
 
 
-DEFAULT_WIREFRAME_FORMATTING: dict[_WireframeComponent, dict[str, Any]] = {
+_WireframeKwargs = WireframeKwargs  # keep for backward compatibility
+
+DEFAULT_WIREFRAME_FORMATTING: dict[WireframeComponent, dict[str, Any]] = {
     'all': dict(color='k'),
     'grid': dict(alpha=0.5, linestyle=':'),
     'equator': dict(linestyle='-'),
@@ -100,9 +114,22 @@ DEFAULT_WIREFRAME_FORMATTING: dict[_WireframeComponent, dict[str, Any]] = {
     'hidden_other_body_of_interest_label': dict(),
     'map_boundary': dict(),
 }
+"""
+Dictionary containing the default formatting settings for all wireframe components,
+which can be modified to customise the default appearance of wireframe plots.
+
+See :func:`Body.plot_wireframe_radec` for more details.
+"""
 
 
-class _AngularCoordinateKwargs(TypedDict, total=False):
+class AngularCoordinateKwargs(TypedDict, total=False):
+    """
+    Class to help type hint keyword arguments of angular coordinate transformations and
+    plotting functions.
+
+    See :func:`Body.radec2angular` for more details.
+    """
+
     origin_ra: float | None
     origin_dec: float | None
     coordinate_rotation: float
@@ -946,7 +973,7 @@ class Body(BodyBase):
         return rotation_matrix @ dec_matrix @ ra_matrix
 
     def _obsvec2angular(
-        self, obsvec: np.ndarray, **angular_kwargs: Unpack[_AngularCoordinateKwargs]
+        self, obsvec: np.ndarray, **angular_kwargs: Unpack[AngularCoordinateKwargs]
     ) -> tuple[float, float]:
         if not (
             math.isfinite(obsvec[0])
@@ -967,7 +994,7 @@ class Body(BodyBase):
         self,
         angular_x: float,
         angular_y: float,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> np.ndarray:
         vec = spice.radrec(
             1.0, -np.deg2rad(angular_x / 3600.0), np.deg2rad(angular_y / 3600.0)
@@ -1020,7 +1047,7 @@ class Body(BodyBase):
         self,
         angular_x: float,
         angular_y: float,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         """
         Convert relative angular coordinates to RA/Dec sky coordinates for the observer.
@@ -1045,7 +1072,7 @@ class Body(BodyBase):
         angular_y: float,
         *,
         not_found_nan: bool = True,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         """
         Convert relative angular coordinates to longitude/latitude coordinates on the
@@ -1078,7 +1105,7 @@ class Body(BodyBase):
         self,
         lon: float,
         lat: float,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         """
         Convert longitude/latitude coordinates on the target body to relative angular
@@ -1197,7 +1224,7 @@ class Body(BodyBase):
         self,
         km_x: float,
         km_y: float,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         """
         Convert distance in target plane to relative angular coordinates.
@@ -1219,7 +1246,7 @@ class Body(BodyBase):
         self,
         angular_x: float,
         angular_y: float,
-        **angular_kwargs: Unpack[_AngularCoordinateKwargs],
+        **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         """
         Convert relative angular coordinates to distances in the target plane.
@@ -2219,7 +2246,7 @@ class Body(BodyBase):
         return self._get_matplotlib_transform(self.km2radec, (0.0, 0.0), ax)
 
     def matplotlib_radec2angular_transform(
-        self, ax: Axes | None = None, **angular_kwargs: Unpack[_AngularCoordinateKwargs]
+        self, ax: Axes | None = None, **angular_kwargs: Unpack[AngularCoordinateKwargs]
     ) -> matplotlib.transforms.Transform:
         return self._get_matplotlib_transform(
             functools.partial(self.radec2angular, **angular_kwargs),
@@ -2228,7 +2255,7 @@ class Body(BodyBase):
         )
 
     def matplotlib_angular2radec_transform(
-        self, ax: Axes | None = None, **angular_kwargs: Unpack[_AngularCoordinateKwargs]
+        self, ax: Axes | None = None, **angular_kwargs: Unpack[AngularCoordinateKwargs]
     ) -> matplotlib.transforms.Transform:
         return self._get_matplotlib_transform(
             functools.partial(self.angular2radec, **angular_kwargs),
@@ -2241,8 +2268,8 @@ class Body(BodyBase):
         *,
         base_formatting: dict[str, Any] | None = None,
         common_formatting: dict[str, Any] | None = None,
-        formatting: dict[_WireframeComponent, dict[str, Any]] | None = None,
-    ) -> dict[_WireframeComponent, dict[str, Any]]:
+        formatting: dict[WireframeComponent, dict[str, Any]] | None = None,
+    ) -> dict[WireframeComponent, dict[str, Any]]:
         formatting = formatting or {}
         base_formatting = base_formatting or {}
         common_formatting = common_formatting or {}
@@ -2251,7 +2278,7 @@ class Body(BodyBase):
         for k in ('show', 'dms_ticks'):
             common_formatting.pop(k, None)
 
-        kwargs: dict[_WireframeComponent, dict[str, Any]] = defaultdict(dict)
+        kwargs: dict[WireframeComponent, dict[str, Any]] = defaultdict(dict)
         for k in set(DEFAULT_WIREFRAME_FORMATTING.keys()) | set(formatting.keys()):
             kwargs[k] = (
                 base_formatting
@@ -2279,7 +2306,7 @@ class Body(BodyBase):
         grid_lat_limit: float = 90,
         indicate_equator: bool = False,
         indicate_prime_meridian: bool = False,
-        formatting: dict[_WireframeComponent, dict[str, Any]] | None = None,
+        formatting: dict[WireframeComponent, dict[str, Any]] | None = None,
         **common_formatting,
     ) -> Axes:
         """
@@ -2421,7 +2448,7 @@ class Body(BodyBase):
         aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         use_shifted_meridian: bool = False,
         show: bool = False,
-        **wireframe_kwargs: Unpack[_WireframeKwargs],
+        **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
         Plot basic wireframe representation of the observation using RA/Dec sky
@@ -2595,7 +2622,7 @@ class Body(BodyBase):
         add_axis_labels: bool = True,
         aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         show: bool = False,
-        **wireframe_kwargs: Unpack[_WireframeKwargs],
+        **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
         Plot basic wireframe representation of the observation on a target centred
@@ -2630,7 +2657,7 @@ class Body(BodyBase):
         add_axis_labels: bool = True,
         aspect_adjustable: Literal['box', 'datalim'] | None = 'datalim',
         show: bool = False,
-        **wireframe_kwargs: Unpack[_WireframeKwargs],
+        **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
         Plot basic wireframe representation of the observation on a relative angular

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -31,7 +31,7 @@ from matplotlib.text import Text
 
 from . import base, data_loader, progress, utils
 from .body import BasicBody, Body, NotFoundError
-from .body_xy import _MapKwargs
+from .body_xy import MapKwargs
 from .observation import Observation
 
 Widget = TypeVar('Widget', bound=tk.Widget)
@@ -2127,7 +2127,7 @@ class SaveObservation(Popup):
     def try_run_save(self) -> None:
         save_nav = bool(self.save_nav.get())
         save_map = bool(self.save_map.get())
-        map_kw: _MapKwargs = {}
+        map_kw: MapKwargs = {}
 
         path_map = self.path_map.get().strip()
         path_nav = self.path_nav.get().strip()
@@ -2215,7 +2215,7 @@ class SavingProgress(Popup):
         save_map: bool,
         path_map: str,
         interpolation: str,
-        map_kw: _MapKwargs,
+        map_kw: MapKwargs,
         keep_open: bool,
     ):
         self.parent = parent

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -13,7 +13,7 @@ from astropy.utils.exceptions import AstropyWarning
 
 from . import common, utils
 from .base import _cache_clearable_result, _cache_stable_result
-from .body_xy import BodyXY, Unpack, _MapKwargs
+from .body_xy import BodyXY, MapKwargs, Unpack
 from .progress import SaveMapProgressHookCLI, SaveNavProgressHookCLI, progress_decorator
 
 T = TypeVar('T')
@@ -688,7 +688,7 @@ class Observation(BodyXY):
         ) = 'linear',
         *,
         spline_smoothing: float = 0,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_kwargs: Unpack[MapKwargs],
     ) -> np.ndarray:
         """
         Projects the observed :attr:`data` onto a map. See
@@ -729,7 +729,7 @@ class Observation(BodyXY):
             Literal['nearest', 'linear', 'quadratic', 'cubic'] | int | tuple[int, int]
         ),
         spline_smoothing: float,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_kwargs: Unpack[MapKwargs],
     ):
         projected = []
         if interpolation == 'linear' and np.any(np.isnan(self.data)):
@@ -1121,7 +1121,7 @@ class Observation(BodyXY):
         wireframe_kwargs: dict[str, Any] | None = None,
         show_progress: bool = False,
         print_info: bool = True,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_kwargs: Unpack[MapKwargs],
     ) -> None:
         """
         Save a FITS file containing the mapped observation in a cylindrical projection.
@@ -1230,7 +1230,7 @@ class Observation(BodyXY):
         *,
         interpolation: str | int | tuple[int, int],
         spline_smoothing: float,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_kwargs: Unpack[MapKwargs],
     ):
         lons, lats, xx, yy, transformer, info = self.generate_map_coordinates(
             **map_kwargs
@@ -1300,7 +1300,7 @@ class Observation(BodyXY):
     def _add_map_wcs_to_header(
         self,
         header: fits.Header,
-        **map_kwargs: Unpack[_MapKwargs],
+        **map_kwargs: Unpack[MapKwargs],
     ) -> None:
         lons, lats, xx, yy, transformer, info = self.generate_map_coordinates(
             **map_kwargs

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,7 +8,7 @@ import planetmapper
 
 
 class TestInit(common_testing.BaseTestCase):
-    def test_init(self):
+    def test_dunder_info(self):
         self.assertEqual(planetmapper.__author__, 'Oliver King')
         self.assertEqual(planetmapper.__url__, 'https://github.com/ortk95/planetmapper')
         self.assertEqual(planetmapper.__license__, 'MIT')
@@ -32,3 +32,37 @@ class TestInit(common_testing.BaseTestCase):
         self.assertLess(
             version.Version(planetmapper.__version__), version.Version('2.0.0')
         )
+
+    def test_all(self):
+        self.assertEqual(len(planetmapper.__all__), 18)  # ensure tests are up to date
+
+        self.assertIs(planetmapper.set_kernel_path, planetmapper.base.set_kernel_path)
+        self.assertIs(planetmapper.get_kernel_path, planetmapper.base.get_kernel_path)
+        self.assertIs(planetmapper.SpiceBase, planetmapper.base.SpiceBase)
+        self.assertIs(planetmapper.Body, planetmapper.body.Body)
+        self.assertIs(planetmapper.Backplane, planetmapper.body_xy.Backplane)
+        self.assertIs(planetmapper.BodyXY, planetmapper.body_xy.BodyXY)
+        self.assertIs(planetmapper.Observation, planetmapper.observation.Observation)
+        self.assertIs(planetmapper.BasicBody, planetmapper.basic_body.BasicBody)
+        self.assertIs(
+            planetmapper.AngularCoordinateKwargs,
+            planetmapper.body.AngularCoordinateKwargs,
+        )
+        self.assertIs(planetmapper.WireframeKwargs, planetmapper.body.WireframeKwargs)
+        self.assertIs(
+            planetmapper.WireframeComponent, planetmapper.body.WireframeComponent
+        )
+        self.assertIs(
+            planetmapper.DEFAULT_WIREFRAME_FORMATTING,
+            planetmapper.body.DEFAULT_WIREFRAME_FORMATTING,
+        )
+        self.assertIs(planetmapper.MapKwargs, planetmapper.body_xy.MapKwargs)
+
+        # test backward compatible aliases
+        self.assertIs(
+            planetmapper.body._WireframeKwargs, planetmapper.body.WireframeKwargs
+        )
+        self.assertIs(
+            planetmapper.body._WireframeComponent, planetmapper.body.WireframeComponent
+        )
+        self.assertIs(planetmapper.body_xy._MapKwargs, planetmapper.body_xy.MapKwargs)


### PR DESCRIPTION
Adds the following type hints/aliases to the public `planetmapper` namespace:
- `AngularCoordinateKwargs`
- `WireframeKwargs`
- `WireframeComponent`
- `MapKwargs`

so e.g. a map keyword argument dictionary can now be accessed using `planetmapper.MapKwargs` rather than using the private `planetmapper.body_xy._MapKwargs`. This also has the nice effect of making the readthedocs function signatures slightly better whenever `Unpack[...Kwargs]` is used. I've kept the old private members as aliases for backward compatibility though.

Closes #327

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.