### PR TITLE
Accept path-like objects for path arguments (in addition to strings) 

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -665,7 +665,7 @@ class BodyBase(SpiceBase):
         return self._radian_pair2degrees(*self._obsvec2radec_radians(obsvec))
 
 
-def load_kernels(*paths, clear_before: bool = False) -> list[str]:
+def load_kernels(*paths: str, clear_before: bool = False) -> list[str]:
     """
     Load spice kernels defined by patterns.
 
@@ -774,7 +774,7 @@ def clear_kernels() -> None:
     _KERNEL_DATA['kernels_loaded'] = False
 
 
-def set_kernel_path(path: str | None) -> None:
+def set_kernel_path(path: str | os.PathLike | None) -> None:
     """
     Set the path of the directory containing SPICE kernels. See
     :ref:`the kernel directory documentation<kernel directory>` for more detail.
@@ -783,6 +783,8 @@ def set_kernel_path(path: str | None) -> None:
         path: Directory which PlanetMapper will search for SPICE kernels. If `None`,
             then the default value of `'~/spice_kernels/'` will be used.
     """
+    if path is not None:
+        path = os.fspath(path)
     _KERNEL_DATA['kernel_path'] = path
 
 

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -135,13 +135,13 @@ class Observation(BodyXY):
         if len(self.data.shape) == 2:
             # Turn data into cube for consistency
             self.data = self.data[np.newaxis, ...]
-        if self.header is not None:
+        if self.header is not None:  # type: ignore
             # use values from header to fill in arguments (e.g. target) which aren't
             # specified by the user
             self._add_kw_from_header(kwargs, self.header)
         super().__init__(nx=self.data.shape[-1], ny=self.data.shape[-2], **kwargs)
 
-        if self.header is None:
+        if self.header is None:  # type: ignore
             self.header = fits.Header(
                 {
                     'OBJECT': self.target,

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -84,7 +84,7 @@ class Observation(BodyXY):
 
     def __init__(
         self,
-        path: str | None = None,
+        path: str | os.PathLike | None = None,
         *,
         data: np.ndarray | None = None,
         header: fits.Header | None = None,
@@ -110,7 +110,7 @@ class Observation(BodyXY):
         `utc` parameters.
         """
         if path is not None:
-            path = os.path.expandvars(os.path.expanduser(path))
+            path = str(os.path.expandvars(os.path.expanduser(path)))
 
         self.path = path
         self.header = None  # type: ignore
@@ -1025,7 +1025,7 @@ class Observation(BodyXY):
     @progress_decorator
     def save_observation(
         self,
-        path: str,
+        path: str | os.PathLike,
         *,
         include_wireframe: bool = True,
         wireframe_kwargs: dict[str, Any] | None = None,
@@ -1057,6 +1057,7 @@ class Observation(BodyXY):
                 creating this `Observation`.
             print_info: Toggle printing of progress information (defaults to `True`).
         """
+        path = os.fspath(path)
         if show_progress and self._get_progress_hook() is None:
             print_info = False
             self._set_progress_hook(SaveNavProgressHookCLI())
@@ -1110,7 +1111,7 @@ class Observation(BodyXY):
     @progress_decorator
     def save_mapped_observation(
         self,
-        path: str,
+        path: str | os.PathLike,
         *,
         interpolation: (
             Literal['nearest', 'linear', 'quadratic', 'cubic'] | int | tuple[int, int]
@@ -1154,6 +1155,7 @@ class Observation(BodyXY):
                 :func:`BodyXY.generate_map_coordinates` to specify and customise the map
                 projection.
         """
+        path = os.fspath(path)
         if show_progress and self._get_progress_hook() is None:
             print_info = False
             self._set_progress_hook(SaveMapProgressHookCLI(len(self.data)))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -749,7 +749,7 @@ class TestFunctions(common_testing.BaseTestCase):
     def test_sort_kernel_paths(self):
         input = [
             '000.txt',
-            '000.txt', # check duplicates are kept
+            '000.txt',  # check duplicates are kept
             'zzz.txt',
             'a/b/c.txt',
             'a/b/file1.txt',

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@ import datetime
 import glob
 import os
 import unittest
+from pathlib import Path
 from typing import Any, Callable, ParamSpec
 from unittest.mock import MagicMock, Mock, patch
 
@@ -411,6 +412,12 @@ class TestKernelPath(common_testing.BaseTestCase):
         planetmapper.set_kernel_path(path)
         self.assertEqual(planetmapper.get_kernel_path(), path)
 
+        path = Path(
+            common_testing.TEMP_PATH, 'test_kernel_path', 'set_kernel_path_pathlike'
+        )
+        planetmapper.set_kernel_path(path)
+        self.assertEqual(planetmapper.get_kernel_path(), os.fspath(path))
+
         self.assertEqual(planetmapper.base.load_kernels(), [])
         self.assertEqual(planetmapper.base.load_kernels(clear_before=True), [])
 
@@ -742,6 +749,7 @@ class TestFunctions(common_testing.BaseTestCase):
     def test_sort_kernel_paths(self):
         input = [
             '000.txt',
+            '000.txt', # check duplicates are kept
             'zzz.txt',
             'a/b/c.txt',
             'a/b/file1.txt',
@@ -763,6 +771,7 @@ class TestFunctions(common_testing.BaseTestCase):
             'x/z/file1.txt',
             'a/kernel.txt',
             'x/000.txt',
+            '000.txt',
             '000.txt',
             'zzz.txt',
         ]


### PR DESCRIPTION
All methods that take a path argument (e.g. `Observation`, `Observation.save_observation`, `set_kernel_path`) can now accept [`os.PathLike`](https://docs.python.org/3/library/os.html#os.PathLike) objects, in addition to strings. For example, these are now equivalent:
```python
from pathlib import Path

Observation(Path('data.fits'))
Observation('data.fits')
```

This is mainly a change to type hints, with a few additional internal checks to ensure any path-like inputs are standardised internally to strings. Any path outputs/attributes (e.g. `Observation.path`) remain as strings.

Closes #348 

### Pull request checklist
- [ ] Add a clear description of the change
- [ ] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.