### PR TITLE
Make `add_satellites_to_bodies_of_interest` more permissive of SPICE errors

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -596,18 +596,24 @@ class Body(BodyBase):
     ) -> 'list[Body | BasicBody]':
         out: 'list[Body | BasicBody]' = []
         id_base = (self.target_body_id // 100) * 100
-        for other_target in range(id_base + 1, id_base + 99):
+        for other_target_id in range(id_base + 1, id_base + 99):
             try:
-                body = self.create_other_body(other_target)
+                body = self.create_other_body(other_target_id)
                 if only_visible and not self.test_if_other_body_visible(body):
                     continue
                 out.append(body)
             except SpiceSPKINSUFFDATA:
                 if skip_insufficient_data:
                     continue
+                try:
+                    spice.bodc2n(other_target_id)
+                except NotFoundError:
+                    # If there is no name defined, then we can skip this ID code as it
+                    # is likely to be for a target that doesn't exist. We only need to
+                    # raise an exception for targets which do exist, but have
+                    # insufficient data.
+                    continue
                 raise
-            except NotFoundError:
-                continue
         return out
 
     def add_satellites_to_bodies_of_interest(
@@ -618,14 +624,16 @@ class Body(BodyBase):
         :attr:`other_bodies_of_interest`.
 
         This uses the NAIF ID codes to identify the satellites. For example, Uranus has
-        an ID of 799, and its satellites have codes 701, 702, 703..., so any object with
-        a code in the range 701 to 798 is added for Uranus.
+        an ID of 799, and its satellites have codes 701, 702, 703..., so any valid
+        object with a code in the range 701 to 798 is added for Uranus.
 
         See also :func:`add_other_bodies_of_interest`.
 
         Args:
             skip_insufficient_data: If True, satellites with insufficient data in the
-                SPICE kernel will be skipped. If False, an exception will be raised.
+                SPICE kernel will be skipped. If False, an exception will be raised if
+                a satellite (a) has a valid ID code (i.e. `spice.bodc2s` works for the
+                satellite) and (b) it has insufficient data.
             only_visible: If `True`, satellites which are hidden behind the target body
                 will not be added.
         """

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -413,6 +413,16 @@ class TestBody(common_testing.BaseTestCase):
         jupiter.other_bodies_of_interest.clear()
         self.assertEqual(jupiter.other_bodies_of_interest, [])
 
+        # This checks the `except NotFoundError` branch works properly
+        earth = planetmapper.Body('earth', utc, observer='HST')
+        earth.add_satellites_to_bodies_of_interest()
+        self.assertEqual(
+            earth.other_bodies_of_interest,
+            [
+                Body('MOON', utc, observer='HST'),
+            ],
+        )
+
     def test_standardise_ring_name(self):
         pairs = [
             ('a', 'a'),


### PR DESCRIPTION
`Body.add_satellites_to_bodies_of_interest` will now silently handle any `SpiceSPKINSUFFDATA` errors for any `other_target_id` that doesn't have an associated name in the SPICE kernels. This ensures that ID codes for non-existent satellites don't raise unneeded errors.

This is basically equivalent to the previous (pre v1.10.0) behaviour, as before #352 any body without a defined name would raise a `NotFoundError` rather than a `SpiceSPKINSUFFDATA` error.

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.