### PR TITLE
Ensure `SpiceBODIESNOTDISTINCT` is raised first if the target and observer are the same

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -392,10 +392,6 @@ class Body(BodyBase):
         else:
             self.positive_longitude_direction = 'E'
 
-        self.target_diameter_arcsec = (
-            2.0 * 60.0 * 60.0 * np.rad2deg(np.arcsin(self.r_eq / self.target_distance))
-        )
-
         # Find sub observer point
         self._subpoint_targvec, self._subpoint_et, self._subpoint_rayvec = spice.subpnt(
             self._subpoint_method_encoded,  # type: ignore
@@ -431,6 +427,14 @@ class Body(BodyBase):
             # If the target is the sun, then there is no sub-solar point
             self.subsol_lon = np.nan
             self.subsol_lat = np.nan
+
+        # Get target diameter
+        # Do this after finding the subpoint so that a SpiceBODIESNOTDISTINCT error
+        # will have already been raised if the target == the observer (which would mean
+        # target_distance=0, causing a numpy warning).
+        self.target_diameter_arcsec = (
+            2.0 * 60.0 * 60.0 * np.rad2deg(np.arcsin(self.r_eq / self.target_distance))
+        )
 
         # Set up equatorial plane (for ring calculations)
         targvec_north_pole = self.lonlat2targvec(0, 90)

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy import array, nan
 from spiceypy.utils.exceptions import (
     NotFoundError,
+    SpiceBODIESNOTDISTINCT,
     SpiceKERNELVARNOTFOUND,
     SpiceSPKINSUFFDATA,
 )
@@ -52,6 +53,11 @@ class TestBody(common_testing.BaseTestCase):
         self.assertEqual(
             saturn.ring_radii, {74658.0, 91975.0, 117507.0, 122340.0, 136780.0}
         )
+
+        # Test SpiceBODIESNOTDISTINCT is raised appropriately, without any divide by
+        # zero errors occuring first
+        with self.assertRaises(SpiceBODIESNOTDISTINCT):
+            planetmapper.Body('earth', observer='earth', utc='2005-01-01')
 
     def test_kernel_errors(self):
         try:


### PR DESCRIPTION
This ensures that if the bodies are the same, the `SpiceBODIESNOTDISTINCT` error will be raised first (by the subpoint calculations), rather than potentially getting a more cryptic divide by zero error from the `target_diameter_arcsec` calculation. This shouldn't have any major change in runtime functionality (as an error was always going to be raised), but should help to make things a little more explicit and clear.

Technically, with the previous version, the `self.r_eq / self.target_distance` would usually cause a numpy warning rather than a full exception, but in some situations this could be raised as an exception (e.g. with `warnings.filterwarnings('error')`. Therefore, this change ensures that the exception isn't affected by the warnings settings and ensures that there aren't any redundant warnings printed just before a much more useful error message.

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.