### PR TITLE
Add `BodyXY.get_img_limits_angular()` method

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -711,6 +711,12 @@ class Body(BodyBase):
     # transformations to/from obsvec. Then any new coordinate system can be added by
     # simply creating a pair of private transformations to/from obsvec, and then adding
     # the relevant public methods.
+    # Methods to add for a new coordinate system:
+    # - all coordinate transforms (xxx2lonlat, lonlat2xxx, xxx2radec...)
+    # - matplotlib transforms (matplotlib_xxx2radec_transform &
+    #     matplotlib_radec2xxx_transform)
+    # - wireframe plotting method
+    # - get_img_limits_xxx method
     # See also BodyBase and BodyXY for some transformations.
 
     # Coordinate transformations target -> observer direction

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -819,6 +819,18 @@ class BodyXY(Body):
         """
         return self._get_img_limits(self.xy2km)
 
+    def get_img_limits_angular(self) -> tuple[tuple[float, float], tuple[float, float]]:
+        """
+        Get the limits of the image coordinates in the relative angular coordinate
+        system. See :func:`get_img_limits_radec`
+
+        Returns:
+            `(angular_x_min, angular_x_max), (angular_y_min, angular_y_max)` tuple
+            containing the minimum and maximum relative angular coordinates of the
+            pixels in the image.
+        """
+        return self._get_img_limits(self.xy2angular)
+
     def get_img_limits_xy(self) -> tuple[tuple[float, float], tuple[float, float]]:
         """
         Get the limits of the image coordinates. See :func:`get_img_limits_radec` for

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -3032,7 +3032,7 @@ class PlotImageSetting(ArtistSetting):
         if image_mode in {'single', 'sum'}:
             try:
                 cmap = self.cmap.get()
-                matplotlib.cm.get_cmap(cmap)
+                plt.get_cmap(cmap)  #  type: ignore
             except ValueError:
                 tkinter.messagebox.showwarning(
                     title='Error parsing colormap',

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -488,7 +488,13 @@ class TestBodyXY(common_testing.BaseTestCase):
         )
 
     def test_img_limits(self):
-        self.assertEqual(self.body.get_img_limits_xy(), ((-0.5, 14.5), (-0.5, 9.5)))
+        self.assertEqual(
+            self.body.get_img_limits_xy(),
+            (
+                (-0.5, 14.5),
+                (-0.5, 9.5),
+            ),
+        )
         self.assertArraysClose(
             self.body.get_img_limits_radec(),
             (
@@ -501,6 +507,13 @@ class TestBodyXY(common_testing.BaseTestCase):
             (
                 (-151724.69753899056, 130727.50016257458),
                 (-125236.31445765976, 117241.42226096484),
+            ),
+        )
+        self.assertArraysClose(
+            self.body.get_img_limits_angular(),
+            (
+                (-31.984379466325663, 27.98633203326517),
+                (-21.98926088314898, 17.99121344984992),
             ),
         )
 


### PR DESCRIPTION
This method was the only missing `get_img_limits_...` method, so adding it ensures all coordinate systems have a full set of methods supported. Also added comment to remind about various methods that should be implemented for any new coordinate systems in the future.

Closes #360.

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.