### PR TITLE
Improve string representations of customised objects

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -309,7 +309,7 @@ class SpiceBase:
         Get kwargs used to __init__ a new object of this class.
 
         This is used by `copy` to copy the options of this object to a new object in
-        conjunction with `_copy_options_to_other`.
+        conjunction with `_copy_options_to_other`. This is also used in `__repr__`.
 
         Subclasses should override this to include any additional information needed to
         build a new object e.g.

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -304,26 +304,6 @@ class SpiceBase:
         """
         return (self._optimize_speed,)
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
-        """
-        Get default values for keyword arguments used to __init__ a new object of this
-        class.
-
-        The order of the keys in the returned dictionary determines the order in which
-        the arguments are displayed in the repr string.
-
-        Subclasses should override this to include any additional kwargs e.g.
-
-                return dict(a=0, b=1, **super()._get_default_init_kwargs())
-        """
-        return dict(
-            show_progress=False,
-            optimize_speed=True,
-            auto_load_kernels=True,
-            kernel_path=None,
-            manual_kernels=None,
-        )
-
     def _get_kwargs(self) -> dict[str, Any]:
         """
         Get kwargs used to __init__ a new object of this class.
@@ -342,6 +322,26 @@ class SpiceBase:
             auto_load_kernels=self._auto_load_kernels,
             kernel_path=self._kernel_path,
             manual_kernels=self._manual_kernels,
+        )
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        """
+        Get default values for keyword arguments used to __init__ a new object of this
+        class.
+
+        The order of the keys in the returned dictionary determines the order in which
+        the arguments are displayed in the repr string.
+
+        Subclasses should override this to include any additional kwargs e.g.
+
+                return dict(a=0, b=1, **super()._get_default_init_kwargs())
+        """
+        return dict(
+            show_progress=False,
+            optimize_speed=True,
+            auto_load_kernels=True,
+            kernel_path=None,
+            manual_kernels=None,
         )
 
     def _copy_options_to_other(self, other: Self) -> None:
@@ -764,7 +764,7 @@ class BodyBase(SpiceBase):
         self.target_ra, self.target_dec = self._obsvec2radec(self._target_obsvec)
 
     def __repr__(self) -> str:
-        return f'BodyBase({self.target!r}, {self.utc!r})'
+        return self._generate_repr('target', 'utc')
 
     def _get_equality_tuple(self) -> tuple:
         return (
@@ -783,6 +783,11 @@ class BodyBase(SpiceBase):
             observer=self.observer,
             aberration_correction=self.aberration_correction,
             observer_frame=self.observer_frame,
+        )
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        return dict(
+            **super()._get_default_init_kwargs(),
         )
 
     def _obsvec2radec_radians(self, obsvec: np.ndarray) -> tuple[float, float]:

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -324,7 +324,8 @@ class SpiceBase:
             manual_kernels=self._manual_kernels,
         )
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         """
         Get default values for keyword arguments used to __init__ a new object of this
         class.
@@ -785,7 +786,8 @@ class BodyBase(SpiceBase):
             observer_frame=self.observer_frame,
         )
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         return dict(
             **super()._get_default_init_kwargs(),
         )

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -4,7 +4,7 @@ import glob
 import math
 import numbers
 import os
-from collections.abc import Collection
+from collections.abc import Collection, Sequence
 from pathlib import Path
 from typing import (
     Any,
@@ -199,7 +199,11 @@ class SpiceBase:
         manual_kernels: None | list[str] = None,
     ) -> None:
         super().__init__()
+        self._show_progress = show_progress
         self._optimize_speed = optimize_speed
+        self._auto_load_kernels = auto_load_kernels
+        self._kernel_path = kernel_path
+        self._manual_kernels = manual_kernels
 
         self._cache = {}
         self._stable_cache = {}
@@ -216,7 +220,67 @@ class SpiceBase:
             )
 
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}()'
+        return self._generate_repr()
+
+    def _generate_repr(
+        self,
+        *arg_keys: str,
+        kwarg_keys: Sequence[str] = (),
+        skip_keys: Collection[str] = (),
+        formatters: dict[str, Callable[[Any], str]] | None = None,
+    ) -> str:
+        """
+        Automatically generate a repr for the object.
+
+        This uses argument information from _get_kwargs and _get_default_init_kwargs to
+        generate a repr string that only includes arguments that have been changed from
+        their default values. Arguments displayed first, without their keywords, can be
+        specified with arg_keys, and kwargs to always include can be specified with
+        kwarg_keys.
+
+        The ordering of the arguments is arg_keys, then kwarg_keys,  then any other
+        kwargs that aren't included in the defaults,then the order defined in
+        _get_default_init_kwargs. By default, values are formatted with repr, but this
+        can be overridden with the formatters dictionary.
+
+        Args:
+            arg_keys: Arguments to include in the repr without their keywords.
+            kwarg_keys: Keyword arguments to always include in the repr.
+            skip_keys: Arguments to always exclude from the repr.
+            formatters: Dictionary mapping argument names to functions that format the
+                argument value for the repr. By default, repr is used.
+
+        Returns:
+            Repr string for the object.
+        """
+        if formatters is None:
+            formatters = {}
+        kwargs = self._get_kwargs()
+        defaults = self._get_default_init_kwargs()
+
+        # skip maybe-default keys explicitly excluded or already included elsewhere
+        skip_keys = set(skip_keys) | set(kwarg_keys) | set(arg_keys)
+
+        kw_to_include = {k: kwargs[k] for k in kwarg_keys}  # explicitly included keys
+        kw_to_include.update(  # keys not included in the defaults
+            {
+                k: v
+                for k, v in kwargs.items()
+                if (k not in skip_keys and k not in defaults)
+            }
+        )
+        kw_to_include.update(  # other keys that don't have their default values
+            {
+                k: kwargs[k]
+                for k, d in defaults.items()
+                if (k not in skip_keys and kwargs[k] != d)
+            }
+        )
+        arguments: list[str] = [formatters.get(k, repr)(kwargs[k]) for k in arg_keys]
+        arguments.extend(
+            f'{k}={formatters.get(k, repr)(v)}' for k, v in kw_to_include.items()
+        )
+        return f'{self.__class__.__name__}({", ".join(arguments)})'
 
     def __eq__(self, other) -> bool:
         return (
@@ -238,7 +302,27 @@ class SpiceBase:
 
         Used by __eq__ and __hash__.
         """
-        return (self._optimize_speed, repr(self))
+        return (self._optimize_speed,)
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        """
+        Get default values for keyword arguments used to __init__ a new object of this
+        class.
+
+        The order of the keys in the returned dictionary determines the order in which
+        the arguments are displayed in the repr string.
+
+        Subclasses should override this to include any additional kwargs e.g.
+
+                return dict(a=0, b=1, **super()._get_default_init_kwargs())
+        """
+        return dict(
+            show_progress=False,
+            optimize_speed=True,
+            auto_load_kernels=True,
+            kernel_path=None,
+            manual_kernels=None,
+        )
 
     def _get_kwargs(self) -> dict[str, Any]:
         """
@@ -252,7 +336,13 @@ class SpiceBase:
 
             return super()._get_kwargs() | dict(a=self.a, b=self.b)
         """
-        return dict(optimize_speed=self._optimize_speed)
+        return dict(
+            show_progress=self._show_progress,
+            optimize_speed=self._optimize_speed,
+            auto_load_kernels=self._auto_load_kernels,
+            kernel_path=self._kernel_path,
+            manual_kernels=self._manual_kernels,
+        )
 
     def _copy_options_to_other(self, other: Self) -> None:
         """

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -273,7 +273,7 @@ class SpiceBase:
             {
                 k: kwargs[k]
                 for k, d in defaults.items()
-                if (k not in skip_keys and kwargs[k] != d)
+                if (k not in skip_keys and not np.array_equal(kwargs[k], d))
             }
         )
         arguments: list[str] = [formatters.get(k, repr)(kwargs[k]) for k in arg_keys]

--- a/planetmapper/basic_body.py
+++ b/planetmapper/basic_body.py
@@ -87,7 +87,8 @@ class BasicBody(BodyBase):
     def _get_equality_tuple(self) -> tuple:
         return (super()._get_equality_tuple(),)
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         return dict(
             observer='EARTH',
             aberration_correction='CN',

--- a/planetmapper/basic_body.py
+++ b/planetmapper/basic_body.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Any
 
 from .base import BodyBase, _add_help_note_to_spice_errors
 
@@ -81,7 +82,15 @@ class BasicBody(BodyBase):
         """Declination (Dec) of the target centre."""
 
     def __repr__(self) -> str:
-        return f'BasicBody({self.target!r}, {self.utc!r})'
+        return self._generate_repr('target', 'utc', kwarg_keys=['observer'])
 
     def _get_equality_tuple(self) -> tuple:
         return (super()._get_equality_tuple(),)
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        return dict(
+            observer='EARTH',
+            aberration_correction='CN',
+            observer_frame='J2000',
+            **super()._get_default_init_kwargs(),
+        )

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -483,7 +483,8 @@ class Body(BodyBase):
             surface_method=self.surface_method,
         )
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         return dict(
             utc=None,
             observer='EARTH',

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -368,6 +368,7 @@ class Body(BodyBase):
         self._surface_method_encoded = self._encode_str(self.surface_method)
 
         # Get target properties and state
+        self._target_frame_arg = target_frame
         if target_frame is None:
             self.target_frame = 'IAU_' + self.target
         else:
@@ -463,8 +464,7 @@ class Body(BodyBase):
                     self.ring_radii.add(r)
 
     def __repr__(self) -> str:
-        # TODO include non-default kwargs in repr?
-        return f'Body({self.target!r}, {self.utc!r}, observer={self.observer!r})'
+        return self._generate_repr('target', 'utc', kwarg_keys=['observer'])
 
     def _get_equality_tuple(self) -> tuple:
         return (
@@ -477,9 +477,23 @@ class Body(BodyBase):
 
     def _get_kwargs(self) -> dict[str, Any]:
         return super()._get_kwargs() | dict(
+            target_frame=self._target_frame_arg,
             illumination_source=self.illumination_source,
             subpoint_method=self.subpoint_method,
             surface_method=self.surface_method,
+        )
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        return dict(
+            utc=None,
+            observer='EARTH',
+            aberration_correction='CN',
+            observer_frame='J2000',
+            target_frame=None,
+            illumination_source='SUN',
+            subpoint_method='INTERCEPT/ELLIPSOID',
+            surface_method='ELLIPSOID',
+            **super()._get_default_init_kwargs(),
         )
 
     def _copy_options_to_other(self, other: Self) -> None:

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -312,7 +312,8 @@ class BodyXY(Body):
             ny=self._ny,
         )
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         return dict(
             nx=0,
             ny=0,

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -164,6 +164,7 @@ class BodyXY(Body):
         self,
         target: str,
         utc: str | datetime.datetime | float | None = None,
+        observer: str | int = 'EARTH',
         nx: int = 0,
         ny: int = 0,
         *,
@@ -177,7 +178,7 @@ class BodyXY(Body):
             nx = sz
             ny = sz
 
-        super().__init__(target, utc, **kwargs)
+        super().__init__(target, utc, observer, **kwargs)
 
         # Document instance variables
         self.backplanes: dict[str, Backplane]
@@ -289,8 +290,9 @@ class BodyXY(Body):
         return new
 
     def __repr__(self) -> str:
-        return f'BodyXY({self.target!r}, {self.utc!r}, {self._nx!r}, {self._ny!r}, observer={self.observer!r})'
+        return self._generate_repr('target', 'utc', kwarg_keys=['observer', 'nx', 'ny'])
 
+    # BodyXY is mutable, so make it unhashable
     __hash__ = None  # type: ignore
 
     def _get_equality_tuple(self) -> tuple:
@@ -308,6 +310,13 @@ class BodyXY(Body):
         return super()._get_kwargs() | dict(
             nx=self._nx,
             ny=self._ny,
+        )
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        return dict(
+            nx=0,
+            ny=0,
+            **super()._get_default_init_kwargs(),
         )
 
     def _copy_options_to_other(self, other: Self) -> None:

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -298,7 +298,7 @@ class GUI:
         self.gui_built = False
 
     def __repr__(self) -> str:
-        return 'InteractiveObservation()'
+        return f'{self.__class__.__name__}()'
 
     def run(self) -> None:
         """

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -158,6 +158,7 @@ class Observation(BodyXY):
                 self.centre_disc()
 
     def __repr__(self) -> str:
+        # XXX use str as formatter for data
         return self._generate_repr('path')
 
     def to_body_xy(self) -> BodyXY:

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -158,7 +158,7 @@ class Observation(BodyXY):
                 self.centre_disc()
 
     def __repr__(self) -> str:
-        return f'Observation({self.path!r})'
+        return self._generate_repr('path')
 
     def to_body_xy(self) -> BodyXY:
         """
@@ -195,6 +195,17 @@ class Observation(BodyXY):
         kw.pop('nx')
         kw.pop('ny')
         return kw
+
+    def _get_default_init_kwargs(self) -> dict[str, Any]:
+        super_defaults = super()._get_default_init_kwargs()
+        super_defaults.pop('nx')
+        super_defaults.pop('ny')
+        return dict(
+            path=None,
+            data=None,
+            header=None,
+            **super_defaults,
+        )
 
     def _load_data_from_path(self):
         assert self.path is not None

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -216,7 +216,8 @@ class Observation(BodyXY):
         kw.pop('ny')
         return kw
 
-    def _get_default_init_kwargs(self) -> dict[str, Any]:
+    @classmethod
+    def _get_default_init_kwargs(cls) -> dict[str, Any]:
         super_defaults = super()._get_default_init_kwargs()
         super_defaults.pop('nx')
         super_defaults.pop('ny')

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -157,9 +157,31 @@ class Observation(BodyXY):
             except ValueError:
                 self.centre_disc()
 
+        # Ensure values used for repr are standardised versions
+        if self._data_arg is not None:
+            self._data_arg = self.data
+        if self._header_arg is not None:
+            self._header_arg = self.header
+
     def __repr__(self) -> str:
-        # XXX use str as formatter for data
         return self._generate_repr('path')
+
+    def __str__(self) -> str:
+        return self._generate_repr(
+            'path',
+            formatters={
+                'data': self._str_array_formatter,
+                'header': self._str_header_formatter,
+            },
+        )
+
+    @staticmethod
+    def _str_array_formatter(array: np.ndarray):
+        return f'<{"x".join(map(str, array.shape))} array>'
+
+    @staticmethod
+    def _str_header_formatter(header: np.ndarray):
+        return f'<{len(header)} card Header>'
 
     def to_body_xy(self) -> BodyXY:
         """
@@ -205,6 +227,7 @@ class Observation(BodyXY):
             path=None,
             data=None,
             header=None,
+            target=None,  # used to position target entry in repr
             **super_defaults,
         )
 

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -164,9 +164,6 @@ class Observation(BodyXY):
             self._header_arg = self.header
 
     def __repr__(self) -> str:
-        return self._generate_repr('path')
-
-    def __str__(self) -> str:
         return self._generate_repr(
             'path',
             formatters={

--- a/tests/common_testing.py
+++ b/tests/common_testing.py
@@ -1,10 +1,13 @@
+import inspect
 import os
 import unittest
 import warnings
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Type
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+import planetmapper
 
 DATA_PATH = os.path.join(os.path.dirname(__file__), 'data')
 KERNEL_PATH = os.path.join(DATA_PATH, 'kernels')
@@ -36,8 +39,8 @@ class BaseTestCase(unittest.TestCase):
 
     def assertArraysClose(
         self,
-        a: Sequence | np.ndarray,
-        b: Sequence | np.ndarray,
+        a: Sequence | np.ndarray | float,
+        b: Sequence | np.ndarray | float,
         *,
         rtol: float = 1e-5,
         atol: float = 1e-8,
@@ -121,3 +124,28 @@ class BaseTestCase(unittest.TestCase):
                             self.assertEqual(ax.get_xlabel(), '')
                             self.assertEqual(ax.get_ylabel(), '')
                         plt.close(fig)
+
+    def _test_get_default_init_kwargs(
+        self, obj_class: Type[planetmapper.SpiceBase], **setup_kwargs
+    ) -> None:
+        # Test with instance
+        obj = obj_class(**setup_kwargs)
+        for k, default in obj._get_default_init_kwargs().items():
+            with self.subTest(k):
+                if k in setup_kwargs:
+                    continue
+                self.assertEqual(obj._get_kwargs()[k], default)
+
+        # Test with inspection
+        signature = inspect.signature(obj_class)
+        for k, default in obj_class._get_default_init_kwargs().items():
+            with self.subTest(k):
+                try:
+                    signature_default = signature.parameters[k].default
+                except KeyError:
+                    # Skip parameters only included in **kwargs part of signature
+                    # (these should implicitly be tested in the parent class)
+                    continue
+                if signature_default is inspect.Signature.empty:
+                    continue
+                self.assertEqual(signature_default, default)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -55,7 +55,16 @@ class TestSpiceBase(common_testing.BaseTestCase):
         # Hashes for unequal object can be the same, so don't do assertNotEqual here
 
     def test_get_kwargs(self):
-        self.assertEqual(self.obj._get_kwargs(), {'optimize_speed': True})
+        self.assertEqual(
+            self.obj._get_kwargs(),
+            {
+                'optimize_speed': True,
+                'kernel_path': None,
+                'auto_load_kernels': True,
+                'manual_kernels': None,
+                'show_progress': False,
+            },
+        )
 
     def test_standardise_body_name(self):
         self.assertEqual(self.obj.standardise_body_name('JUPITER'), 'JUPITER')

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -45,6 +45,69 @@ class TestSpiceBase(common_testing.BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(str(self.obj), 'SpiceBase()')
+        self.assertEqual(repr(self.obj), 'SpiceBase()')
+
+        self.assertEqual(
+            str(planetmapper.SpiceBase(show_progress=False)), 'SpiceBase()'
+        )
+        self.assertEqual(
+            str(planetmapper.SpiceBase(show_progress=True)),
+            'SpiceBase(show_progress=True)',
+        )
+        self.assertEqual(
+            str(
+                planetmapper.SpiceBase(
+                    True,
+                    auto_load_kernels=False,
+                    optimize_speed=False,
+                    manual_kernels=['a', 'b', 'c'],
+                )
+            ),
+            "SpiceBase(show_progress=True, optimize_speed=False, auto_load_kernels=False, manual_kernels=['a', 'b', 'c'])",
+        )
+
+    def test_generate_repr(self):
+        obj = planetmapper.SpiceBase(
+            True,
+            auto_load_kernels=False,
+            optimize_speed=False,
+            manual_kernels=['a', 'b', 'c'],
+        )
+        self.assertEqual(
+            obj._generate_repr(),
+            "SpiceBase(show_progress=True, optimize_speed=False, auto_load_kernels=False, manual_kernels=['a', 'b', 'c'])",
+        )
+        self.assertEqual(
+            obj._generate_repr('optimize_speed'),
+            "SpiceBase(False, show_progress=True, auto_load_kernels=False, manual_kernels=['a', 'b', 'c'])",
+        )
+        self.assertEqual(
+            obj._generate_repr('manual_kernels', 'optimize_speed'),
+            "SpiceBase(['a', 'b', 'c'], False, show_progress=True, auto_load_kernels=False)",
+        )
+        self.assertEqual(
+            obj._generate_repr('kernel_path'),
+            "SpiceBase(None, show_progress=True, optimize_speed=False, auto_load_kernels=False, manual_kernels=['a', 'b', 'c'])",
+        )
+        self.assertEqual(
+            obj._generate_repr(kwarg_keys=['kernel_path', 'auto_load_kernels']),
+            "SpiceBase(kernel_path=None, auto_load_kernels=False, show_progress=True, optimize_speed=False, manual_kernels=['a', 'b', 'c'])",
+        )
+        self.assertEqual(
+            obj._generate_repr(
+                skip_keys=['kernel_path', 'auto_load_kernels', 'manual_kernels']
+            ),
+            'SpiceBase(show_progress=True, optimize_speed=False)',
+        )
+        self.assertEqual(
+            obj._generate_repr(
+                formatters={
+                    'show_progress': lambda x: f'>>{x}<<',
+                    'manual_kernels': lambda x: '&'.join(x),
+                }
+            ),
+            'SpiceBase(show_progress=>>True<<, optimize_speed=False, auto_load_kernels=False, manual_kernels=a&b&c)',
+        )
 
     def test_eq(self):
         self.assertEqual(self.obj, planetmapper.SpiceBase())

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -43,6 +43,9 @@ class TestSpiceBase(common_testing.BaseTestCase):
         obj = planetmapper.SpiceBase(show_progress=True)
         self.assertIsNotNone(obj._get_progress_hook())
 
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(planetmapper.SpiceBase)
+
     def test_repr(self):
         self.assertEqual(str(self.obj), 'SpiceBase()')
         self.assertEqual(repr(self.obj), 'SpiceBase()')
@@ -641,6 +644,16 @@ class TestBodyBase(common_testing.BaseTestCase):
             )
             obj = BodyBase(utc=None, **kw)
             self.assertEqual(obj.utc, '2005-01-01T12:30:00.000000')
+
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(
+            BodyBase,
+            target='jupiter',
+            utc='2005-01-01',
+            observer='earth',
+            aberration_correction='CN+S',
+            observer_frame='J2000',
+        )
 
     def test_eq(self):
         obj = BodyBase(

--- a/tests/test_basic_body.py
+++ b/tests/test_basic_body.py
@@ -29,7 +29,8 @@ class TestBasicBody(common_testing.BaseTestCase):
 
     def test_repr(self):
         self.assertEqual(
-            repr(self.body), "BasicBody('JUPITER', '2005-01-01T00:00:00.000000')"
+            repr(self.body),
+            "BasicBody('JUPITER', '2005-01-01T00:00:00.000000', observer='HST')",
         )
 
     def test_eq(self):

--- a/tests/test_basic_body.py
+++ b/tests/test_basic_body.py
@@ -12,6 +12,11 @@ class TestBasicBody(common_testing.BaseTestCase):
         planetmapper.set_kernel_path(common_testing.KERNEL_PATH)
         self.body = BasicBody('Jupiter', observer='HST', utc='2005-01-01T00:00:00')
 
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(
+            BasicBody, target='Jupiter', utc='2005-01-01T00:00:00'
+        )
+
     def test_attributes(self):
         self.assertEqual(self.body.target, 'JUPITER')
         self.assertEqual(self.body.utc, '2005-01-01T00:00:00.000000')

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -28,6 +28,11 @@ class TestBody(common_testing.BaseTestCase):
         planetmapper.set_kernel_path(common_testing.KERNEL_PATH)
         self.body = Body('Jupiter', observer='HST', utc='2005-01-01T00:00:00')
 
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(
+            Body, target='Jupiter', utc='2005-01-01T00:00:00'
+        )
+
     def test_init(self):
         self.assertAlmostEqual(
             Body('Jupiter', utc='2005-01-01').subpoint_lon,

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -151,6 +151,20 @@ class TestBody(common_testing.BaseTestCase):
             repr(self.body),
             "Body('JUPITER', '2005-01-01T00:00:00.000000', observer='HST')",
         )
+        self.assertEqual(
+            repr(
+                Body(
+                    'Jupiter',
+                    observer='HST',
+                    utc='2005-01-01T00:00:00',
+                    show_progress=True,
+                    aberration_correction='CN+S',
+                    optimize_speed=False,
+                    auto_load_kernels=True,
+                )
+            ),
+            "Body('JUPITER', '2005-01-01T00:00:00.000000', observer='HST', aberration_correction='CN+S', show_progress=True, optimize_speed=False)",
+        )
 
     def test_eq(self):
         self.assertEqual(self.body, self.body)

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -206,7 +206,12 @@ class TestBody(common_testing.BaseTestCase):
             self.body._get_kwargs(),
             {
                 'optimize_speed': True,
+                'show_progress': False,
+                'auto_load_kernels': True,
+                'kernel_path': None,
+                'manual_kernels': None,
                 'target': 'JUPITER',
+                'target_frame': None,
                 'utc': '2005-01-01T00:00:00.000000',
                 'observer': 'HST',
                 'aberration_correction': 'CN',

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -152,11 +152,11 @@ class TestBodyXY(common_testing.BaseTestCase):
     def test_repr(self):
         self.assertEqual(
             repr(self.body),
-            "BodyXY('JUPITER', '2005-01-01T00:00:00.000000', 15, 10, observer='HST')",
+            "BodyXY('JUPITER', '2005-01-01T00:00:00.000000', observer='HST', nx=15, ny=10)",
         )
         self.assertEqual(
             repr(self.body_zero_size),
-            "BodyXY('JUPITER', '2005-01-01T00:00:00.000000', 0, 0, observer='HST')",
+            "BodyXY('JUPITER', '2005-01-01T00:00:00.000000', observer='HST', nx=0, ny=0)",
         )
 
     def test_eq(self):
@@ -192,7 +192,12 @@ class TestBodyXY(common_testing.BaseTestCase):
             self.body._get_kwargs(),
             {
                 'optimize_speed': True,
+                'show_progress': False,
+                'auto_load_kernels': True,
+                'kernel_path': None,
+                'manual_kernels': None,
                 'target': 'JUPITER',
+                'target_frame': None,
                 'utc': '2005-01-01T00:00:00.000000',
                 'observer': 'HST',
                 'aberration_correction': 'CN',

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -76,6 +76,11 @@ class TestBodyXY(common_testing.BaseTestCase):
             'Jupiter', observer='HST', utc='2005-01-01T00:00:00'
         )
 
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(
+            BodyXY, target='jupiter', utc='2005-01-01T00:00:00'
+        )
+
     def test_init(self):
         self.assertEqual(
             BodyXY('jupiter', utc='2005-01-01T00:00:00', sz=50),

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -22,6 +22,15 @@ class TestObservation(common_testing.BaseTestCase):
         self.path = os.path.join(common_testing.DATA_PATH, 'inputs', 'test.fits')
         self.observation = Observation(self.path)
 
+    def test_get_default_init_kwargs(self):
+        self._test_get_default_init_kwargs(
+            Observation,
+            path=self.path,
+            target='Jupiter',
+            observer='hst',
+            utc='2005-01-01T00:00:00',
+        )
+
     def test_init(self) -> None:
         with self.assertRaises(ValueError):
             Observation()
@@ -322,7 +331,7 @@ class TestObservation(common_testing.BaseTestCase):
                     aberration_correction='NONE',
                 )
             ),
-            "Observation(None, data=<300x400x500 array>, header=<2 card header>, target='JUPITER', utc='2005-01-01T00:00:00.000000', observer='HST', aberration_correction='NONE')",
+            "Observation(None, data=<300x400x500 array>, header=<2 card Header>, target='JUPITER', utc='2005-01-01T00:00:00.000000', observer='HST', aberration_correction='NONE')",
         )
 
     def test_to_body_xy(self):

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -307,7 +307,10 @@ class TestObservation(common_testing.BaseTestCase):
         self.assertEqual(self.observation._ny, 10)
 
     def test_repr(self):
-        self.assertEqual(repr(self.observation), f'Observation({self.path!r})')
+        self.assertEqual(
+            repr(self.observation),
+            f"Observation({self.path!r}, target='JUPITER', utc='2005-01-01T00:00:00.000000', observer='HST')",
+        )
 
     def test_to_body_xy(self):
         observation = Observation(

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -311,6 +311,19 @@ class TestObservation(common_testing.BaseTestCase):
             repr(self.observation),
             f"Observation({self.path!r}, target='JUPITER', utc='2005-01-01T00:00:00.000000', observer='HST')",
         )
+        self.assertEqual(
+            str(
+                planetmapper.Observation(
+                    data=np.ones((300, 400, 500)),
+                    header=fits.Header({'target': 'Jupiter', 'abc': 123}),
+                    target='Jupiter',
+                    observer='HST',
+                    utc='2005-01-01T00:00:00',
+                    aberration_correction='NONE',
+                )
+            ),
+            "Observation(None, data=<300x400x500 array>, header=<2 card header>, target='JUPITER', utc='2005-01-01T00:00:00.000000', observer='HST', aberration_correction='NONE')",
+        )
 
     def test_to_body_xy(self):
         observation = Observation(


### PR DESCRIPTION
String representations (e.g. from `str()` or `repr()`) of objects now include any extra arguments used to customise the object. These arguments are only included in the string if they have been changed from their default values, keeping the string concise. For example:

```python
body = planetmapper.Body('JUPITER', '2000-01-01T00:00:00.000000', observer='EARTH', illumination_source='Europa')

# New behaviour:
print(body)
# Body('JUPITER', '2000-01-01T00:00:00.000000', observer='EARTH', illumination_source='Europa')

# Old behaviour (note the customised illumination source was missing):
print(body)
# Body('JUPITER', '2000-01-01T00:00:00.000000', observer='EARTH')
```

This is implemented for all objects by defining a (private) dictionary of the default argument values used to initialise the object, then using this to automatically include non-default arguments in the string. Therefore, any new objetcs/subclasses simply need to add any new arguments to `_get_default_init_kwargs`, then `_generate_repr` can be used to automatically generate a desired string. 

Closes #351.

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.