### PR TITLE
Ensure `angular_dist` returns a valid values 

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -664,12 +664,18 @@ class SpiceBase:
         Returns:
             Angular distance in degrees between the two points.
         """
+        # Clip to prevent floating point errors causing arccos to return NaN
+        # e.g. https://github.com/ortk95/planetmapper/issues/357
         return np.rad2deg(
             np.arccos(
-                np.sin(np.deg2rad(dec1)) * np.sin(np.deg2rad(dec2))
-                + np.cos(np.deg2rad(dec1))
-                * np.cos(np.deg2rad(dec2))
-                * np.cos(np.deg2rad(ra1) - np.deg2rad(ra2))
+                np.clip(
+                    np.sin(np.deg2rad(dec1)) * np.sin(np.deg2rad(dec2))
+                    + np.cos(np.deg2rad(dec1))
+                    * np.cos(np.deg2rad(dec2))
+                    * np.cos(np.deg2rad(ra1) - np.deg2rad(ra2)),
+                    -1.0,
+                    1.0,
+                )
             )
         )
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -317,6 +317,15 @@ class TestSpiceBase(common_testing.BaseTestCase):
             ((0, 0, 0, 0), 0),
             ((1, 2, 3, 4), 2.8264172166624126),
             ((-42, 0, 1234.5678, 99), 81.37656372202063),
+            (  # https://github.com/ortk95/planetmapper/issues/357
+                (
+                    33.32295445419726,
+                    12.216622516821692,
+                    33.32295445419726,
+                    12.216622516821692,
+                ),
+                0,
+            ),
         ]
         for angles, dist in pairs:
             with self.subTest(angles):


### PR DESCRIPTION
For some input values (e.g. for identical input points), `SpiceBase.angular_dist` returned NaN. This was due to the accumulation of small floating point errors causing the code to evaluate e.g. `np.arccos(1.0000000000000002) -> NaN` rather than the correct `np.arccos(1.0) -> 0.0`. This has been fixed by clipping the value in `np.arccos` to ensure it always lies between -1 and 1.

Closes #357

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.