### PR TITLE
Allow customisation of the altitude when converting from `lonlat` coordinates

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -915,6 +915,7 @@ class Body(BodyBase):
         self,
         ra: float,
         dec: float,
+        *,
         not_found_nan: bool = True,
     ) -> tuple[float, float]:
         """
@@ -1252,7 +1253,7 @@ class Body(BodyBase):
         return self._obsvec2km(self._radec2obsvec_norm(ra, dec))
 
     def km2lonlat(
-        self, km_x: float, km_y: float, not_found_nan: bool = True
+        self, km_x: float, km_y: float, *, not_found_nan: bool = True
     ) -> tuple[float, float]:
         """
         Convert distance in target plane to longitude/latitude coordinates on the target

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -384,7 +384,9 @@ class BodyXY(Body):
         """
         return self._obsvec2xy(self._radec2obsvec_norm(ra, dec))
 
-    def xy2lonlat(self, x: float, y: float, not_found_nan=True) -> tuple[float, float]:
+    def xy2lonlat(
+        self, x: float, y: float, *, not_found_nan=True
+    ) -> tuple[float, float]:
         """
         Convert image pixel coordinates to longitude/latitude coordinates on the target
         body.

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -406,18 +406,21 @@ class BodyXY(Body):
         """
         return self._obsvec_norm2lonlat(self._xy2obsvec_norm(x, y), not_found_nan)
 
-    def lonlat2xy(self, lon: float, lat: float) -> tuple[float, float]:
+    def lonlat2xy(
+        self, lon: float, lat: float, *, alt: float = 0.0
+    ) -> tuple[float, float]:
         """
         Convert longitude/latitude on the target body to image pixel coordinates.
 
         Args:
             lon: Longitude of point on target body.
             lat: Latitude of point on target body.
+            alt: Altitude of point above the surface of the target body in km.
 
         Returns:
             `(x, y)` tuple containing the image pixel coordinates of the point.
         """
-        return self._obsvec2xy(self._lonlat2obsvec(lon, lat))
+        return self._obsvec2xy(self._lonlat2obsvec(lon, lat, alt=alt))
 
     def xy2km(self, x: float, y: float) -> tuple[float, float]:
         """

--- a/tests/common_testing.py
+++ b/tests/common_testing.py
@@ -48,8 +48,14 @@ class BaseTestCase(unittest.TestCase):
     ) -> None:
         if not np.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan):
             diff = np.abs(np.array(a) - np.array(b))
-            aerr = np.nanmax(diff)
-            max_b = np.nanmax(np.abs(b))
+            if np.all(np.isnan(diff)):
+                aerr = np.nan
+            else:
+                aerr = np.nanmax(diff)
+            if np.all(np.isnan(b)):
+                max_b = np.nan
+            else:
+                max_b = np.nanmax(np.abs(b))
             if max_b == 0:
                 relerr = np.inf
             else:

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -521,6 +521,22 @@ class TestBody(common_testing.BaseTestCase):
                     np.allclose(self.body.lonlat2radec(*lonlat), radec, equal_nan=True)
                 )
 
+        pairs_with_alts: list[
+            tuple[tuple[float, float, float], tuple[float, float]]
+        ] = [
+            ((42, 23.4, 0), (196.36871162182828, -5.5624995718895915)),
+            ((42, 23.4, -123.456), (196.36871704240835, -5.562505596011716)),
+            ((42, 23.4, 1234.567), (196.3686574157507, -5.562439330354751)),
+            ((42, 23.4, nan), (nan, nan)),
+        ]
+        for (lon, lat, alt), expected in pairs_with_alts:
+            with self.subTest((lon, lat, alt)):
+                self.assertArraysClose(
+                    self.body.lonlat2radec(lon, lat, alt=alt),
+                    expected,
+                    equal_nan=True,
+                )
+
     def test_radec2lonlat(self):
         self.assertTrue(
             np.array_equal(
@@ -581,6 +597,26 @@ class TestBody(common_testing.BaseTestCase):
                     np.allclose(
                         self.body.lonlat2targvec(lon, lat), targvec, equal_nan=True
                     )
+                )
+
+        pairs_with_alts: list[tuple[tuple[float, float, float], np.ndarray]] = [
+            ((42, 23.4, 0), array([49249.33355035, -44344.29910771, 25077.9757777])),
+            (
+                (42, 23.4, -123.456),
+                array([49165.13352119, -44268.48506093, 25028.94548771]),
+            ),
+            (
+                (42, 23.4, 1234.567),
+                array([50091.3386161, -45102.44387423, 25568.2814576]),
+            ),
+            ((42, 23.4, nan), array([nan, nan, nan])),
+        ]
+        for (lon, lat, alt), expected in pairs_with_alts:
+            with self.subTest((lon, lat, alt)):
+                self.assertArraysClose(
+                    self.body.lonlat2targvec(lon, lat, alt=alt),
+                    expected,
+                    equal_nan=True,
                 )
 
     def test_targvec2lonlat(self):
@@ -733,6 +769,22 @@ class TestBody(common_testing.BaseTestCase):
                     all(not np.isfinite(x) for x in self.body.lonlat2angular(*a))
                 )
 
+        pairs_with_alts: list[
+            tuple[tuple[float, float, float], tuple[float, float]]
+        ] = [
+            ((42, 23.4, 0), (11.730907264131929, 11.859358373960486)),
+            ((42, 23.4, -123.456), (11.711484946681594, 11.837671641863478)),
+            ((42, 23.4, 1234.567), (11.92513145342673, 12.076226814058423)),
+            ((42, 23.4, nan), (nan, nan)),
+        ]
+        for (lon, lat, alt), expected in pairs_with_alts:
+            with self.subTest((lon, lat, alt)):
+                self.assertArraysClose(
+                    self.body.lonlat2angular(lon, lat, alt=alt),
+                    expected,
+                    equal_nan=True,
+                )
+
     def test_km_rotation(self):
         x_target, y_target = self.body.radec2km(
             self.body.target_ra, self.body.target_dec
@@ -804,6 +856,22 @@ class TestBody(common_testing.BaseTestCase):
                 )
                 self.assertTrue(
                     all(not np.isfinite(x) for x in self.body.lonlat2km(*a))
+                )
+
+        pairs_with_alts: list[
+            tuple[tuple[float, float, float], tuple[float, float]]
+        ] = [
+            ((42, 23.4, 0), (61817.98981185463, 23924.02130814744)),
+            ((42, 23.4, -123.456), (61712.30433782919, 23876.972243949425)),
+            ((42, 23.4, 1234.567), (62874.850051314235, 24394.514357706197)),
+            ((42, 23.4, nan), (nan, nan)),
+        ]
+        for (lon, lat, alt), expected in pairs_with_alts:
+            with self.subTest((lon, lat, alt)):
+                self.assertArraysClose(
+                    self.body.lonlat2km(lon, lat, alt=alt),
+                    expected,
+                    equal_nan=True,
                 )
 
     def test_km_angular(self):
@@ -963,6 +1031,22 @@ class TestBody(common_testing.BaseTestCase):
             with self.subTest(lonlat=lonlat):
                 self.assertEqual(
                     self.body.test_if_lonlat_visible(*lonlat), visible, lonlat
+                )
+
+        pairs_with_alts: list[tuple[tuple[float, float, float], bool]] = [
+            ((0, 0, 0), False),
+            ((0, 0, 1000000.0), True),
+            ((0, 0, -1000000.0), True),
+            ((153.1, -3.0, 0), True),
+            ((153.1, -3.0, -1), False),
+            ((153.1, -3.0, 1), True),
+            ((153.1, -3.0, nan), False),
+            ((153.1, nan, 1), False),
+        ]
+        for (lon, lat, alt), visible in pairs_with_alts:
+            with self.subTest(lon=lon, lat=lat, alt=alt):
+                self.assertEqual(
+                    self.body.test_if_lonlat_visible(lon, lat, alt=alt), visible
                 )
 
     def test_other_body_los_intercept(self):

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1222,32 +1222,35 @@ class TestBody(common_testing.BaseTestCase):
         )
 
     def test_ring_radec(self):
-        self.assertTrue(
-            np.allclose(
-                self.body.ring_radec(10000, npts=5),
-                (
-                    array([nan, 196.37142013, 196.37228744, nan, nan]),
-                    array([nan, -5.5655251, -5.56589635, nan, nan]),
-                ),
-                equal_nan=True,
-            )
+        # inside jupiter
+        self.assertArraysClose(
+            self.body.ring_radec(10000, npts=5),
+            (
+                array([nan, nan, nan, nan, nan]),
+                array([nan, nan, nan, nan, nan]),
+            ),
+            equal_nan=True,
         )
-        self.assertTrue(
-            np.allclose(
-                self.body.ring_radec(123456.789, npts=3, only_visible=False),
-                (
-                    array([196.36825958, 196.37571178, 196.36825958]),
-                    array([-5.56452821, -5.56705935, -5.56452821]),
-                ),
-                equal_nan=True,
-            )
+        self.assertArraysClose(
+            self.body.ring_radec(100000, npts=5),
+            (
+                array([nan, 196.36633034, 196.37500382, 196.37764017, nan]),
+                array([nan, -5.56310623, -5.56681892, -5.56848105, nan]),
+            ),
+            equal_nan=True,
         )
-        self.assertTrue(
-            np.allclose(
-                self.body.ring_radec(np.nan, npts=2, only_visible=False),
-                (array([nan, nan]), array([nan, nan])),
-                equal_nan=True,
-            )
+        self.assertArraysClose(
+            self.body.ring_radec(123456.789, npts=3, only_visible=False),
+            (
+                array([196.36825958, 196.37571178, 196.36825958]),
+                array([-5.56452821, -5.56705935, -5.56452821]),
+            ),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.ring_radec(np.nan, npts=2, only_visible=False),
+            (array([nan, nan]), array([nan, nan])),
+            equal_nan=True,
         )
 
     def test_visible_lonlat_grid_radec(self):

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -363,9 +363,9 @@ class TestBodyXY(common_testing.BaseTestCase):
         pairs_with_alts: list[
             tuple[tuple[float, float, float], tuple[float, float]]
         ] = [
-            ((42, 23.4, 0), (10.434159101371755, 7.966287562069517)),
-            ((42, 23.4, -123.456), (10.429301150640963, 7.960863231203309)),
-            ((42, 23.4, 1234.567), (10.482738862501428, 8.020531150650195)),
+            ((42, 23.4, 0), (7.781497231832574, 8.015145501618983)),
+            ((42, 23.4, -123.456), (7.776650117803703, 8.014878507462662)),
+            ((42, 23.4, 1234.567), (7.829968623728911, 8.017815455484365)),
             ((42, 23.4, nan), (nan, nan)),
         ]
         for (lon, lat, alt), expected in pairs_with_alts:
@@ -630,15 +630,22 @@ class TestBodyXY(common_testing.BaseTestCase):
 
     def test_ring_xy(self):
         self.body.set_disc_params(5, 8, 10, 45)
-        self.assertTrue(
-            np.allclose(
-                self.body.ring_xy(1234.5678, npts=4),
-                (
-                    array([nan, 5.09062199, 4.8390282, nan]),
-                    array([nan, 7.97280096, 8.06177746, nan]),
-                ),
-                equal_nan=True,
-            )
+        # inside jupiter
+        self.assertArraysClose(
+            self.body.ring_xy(1234.5678, npts=4),
+            (
+                array([nan, nan, nan, nan]),
+                array([nan, nan, nan, nan]),
+            ),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.ring_xy(123456.789, npts=5),
+            (
+                array([nan, 19.52699622, -2.03791988, -9.52453066, nan]),
+                array([nan, 2.86248741, 11.45672546, 13.13660032, nan]),
+            ),
+            equal_nan=True,
         )
 
     @patch('matplotlib.pyplot.show')

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -360,6 +360,22 @@ class TestBodyXY(common_testing.BaseTestCase):
                 self.assertTrue(not all(np.isfinite(self.body.lonlat2xy(*a))))
                 self.assertTrue(not all(np.isfinite(self.body.km2xy(*a))))
 
+        pairs_with_alts: list[
+            tuple[tuple[float, float, float], tuple[float, float]]
+        ] = [
+            ((42, 23.4, 0), (10.434159101371755, 7.966287562069517)),
+            ((42, 23.4, -123.456), (10.429301150640963, 7.960863231203309)),
+            ((42, 23.4, 1234.567), (10.482738862501428, 8.020531150650195)),
+            ((42, 23.4, nan), (nan, nan)),
+        ]
+        for (lon, lat, alt), expected in pairs_with_alts:
+            with self.subTest((lon, lat, alt)):
+                self.assertArraysClose(
+                    self.body.lonlat2xy(lon, lat, alt=alt),
+                    expected,
+                    equal_nan=True,
+                )
+
     def test_set_disc_params(self):
         x0, y0, r0, rotation = [1.1, 2.2, 3.3, 4.4]
         self.body.set_disc_params(x0, y0, r0, rotation)


### PR DESCRIPTION
Added an additional `alt` keyword only parameter to transformations from longitude/latitude coordinates, which allows the altitude of the point to be specified. For example, you can now specify the altitude with methods like:

```python
body.lonlat2radec(..., alt=500)
body.test_if_lonlat_visible(..., alt=500)
body.visible_lonlat_grid_radec(alt=500)
```

The altitude is specified in kilometers above the planet's surface, and defaults to `alt=0` (so the default behaviour is unchanged).

This example shows how this new PlanetMapper functionality can be used to plot a longitide/latitude grid at an altitude of 10,000km above the surface (i.e. the 1-bar level) of Jupiter:

```python
body = planetmapper.Body('Jupiter', utc='2005-01-01T00:00:00')
body.plot_wireframe_radec()
for ras, decs in body.visible_lonlat_grid_radec(alt=1e4):
    plt.plot(ras, decs, color='r', alpha=0.5)
plt.show()
```
![image](https://github.com/ortk95/planetmapper/assets/26504228/92ef9ae3-d0bc-4378-91f6-871fbe6eed3e)

The calculation of if a point is visible (`Body.test_if_lonlat_visible`) has also been rewritten to work correctly with arbitrary altitudes. If the altitude is zero (i.e. the point is on the surface), the calculation is unchanged, using the SPICE `illumf` function. However, for a non-zero altitude, the calculation now searches for any intercept with the target's surface along the line of sight from the observer (using SPICE's `sincpt`), and uses this to identify if the point is visible, or obscured by the target. This ensures that points at altitude that are "behind" the target, but still visible, are calculated correctly.

Closes #359.


### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.