### PR TITLE
Allow passing arrays to coordinate transformation methods

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -714,11 +714,13 @@ class SpiceBase:
         if isinstance(arg1, numeric_types) and isinstance(arg2, numeric_types):
             return func(arg1, arg2, *args, **kwargs)  # type: ignore
         else:
-            with np.nditer([arg1, arg2, None, None]) as it:  # type: ignore
+            # the op_dtypes argument ensures that the output arrays are floats, as
+            # otherwise we could end up with e.g. int arrays which would then truncate
+            # values, potentially leading to errors
+            with np.nditer([arg1, arg2, None, None], op_dtypes=[None, None, float, float]) as it:  # type: ignore
                 for a, b, u, v in it:
                     u[...], v[...] = func(a, b, *args, **kwargs)  #  type: ignore
                 return it.operands[2], it.operands[3]  #  type: ignore
-        # XXX test
         # TODO improve performance by using alt context manager for arrays
         # (e.g. add context manager in radec2lonlat)
 

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -663,6 +663,58 @@ class TestBody(common_testing.BaseTestCase):
                     expected,
                     equal_nan=True,
                 )
+        # Test array broadcasting implementation
+        self.assertArraysClose(
+            self.body.lonlat2radec(
+                np.array([0, 90, 123]),
+                np.array([1, 2, 3]),
+                alt=123.456,
+                not_visible_nan=True,
+            ),
+            (
+                array([nan, 196.36800057, 196.3698629]),
+                array([nan, -5.56373086, -5.56437196]),
+            ),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.lonlat2radec(
+                [[0, 90, 123], [100, 200, 300.123]],
+                0,
+                alt=123.456,
+                not_visible_nan=True,
+            ),
+            (
+                array(
+                    [
+                        [nan, 196.36793564, 196.36976609],
+                        [196.36837244, 196.37540197, nan],
+                    ]
+                ),
+                array(
+                    [[nan, -5.56386914, -5.56457942], [-5.56402583, -5.56714199, nan]]
+                ),
+            ),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.lonlat2radec(lon=123, lat=-12.34),
+            (196.3694301738864, -5.5654598621335625),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.lonlat2radec([[[[123]]]], -12.34),
+            (array([[[[196.36943017]]]]), array([[[[-5.56545986]]]])),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.lonlat2radec([np.nan, np.inf, 0, 1.234, 1234], 0),
+            (
+                array([nan, nan, 196.3698279, 196.36974134, 196.37215256]),
+                array([nan, nan, -5.56506094, -5.56501974, -5.56561021]),
+            ),
+            equal_nan=True,
+        )
 
     def test_radec2lonlat(self):
         self.assertTrue(


### PR DESCRIPTION
Array transformation methods (e.g. `radec2lonlat`) can now transform arrays of coordinates, in addition to coordinates for a single point.

If the input coordinates are both floats, then the method will return a tuple of floats (i.e. the existing behaviour). If either of the input coordinates are arrays, then the inputs will be [broadcast together](https://numpy.org/doc/stable/user/basics.broadcasting.html), and a tuple of NumPy arrays will be returned. There are no restrictions on the shape and number of dimensions of the input arrays - the only requirement is that the input arrays can be broadcast together.

For example:
```python
body = planetmapper.Body('Jupiter', utc='2005-01-01T00:00:00')

print(body.lonlat2radec(180, 0))
# (196.3742463154229, -5.566702383405959)
print(body.lonlat2radec(np.arange(360), np.zeros(360)))
# (array([196.36993081, ..., 196.37000169]), array([-5.5652366 , ..., -5.56527024]))
print(body.lonlat2radec(np.array([1,2]), np.array([[1,2],[3,4]])))
# (array([[196.36989221, 196.36985491], [196.3699572, 196.36992117]]), array([[-5.56513378, -5.56503142], [-5.56499563, -5.5648938 ]]))
```


Closes #358 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.