### PR TITLE
Accept arrays in `graphic2centric_lonlat` and `centric2graphic_lonlat`

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2609,10 +2609,16 @@ class Body(BodyBase):
         return self._radian_pair2degrees(lon_centric, lat_centric)
 
     def graphic2centric_lonlat(
-        self, lon: float, lat: float, *, alt: float = 0.0
-    ) -> tuple[float, float]:
+        self, lon: FloatOrArray, lat: FloatOrArray, *, alt: float = 0.0
+    ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert planetographic longitude/latitude to planetocentric.
+
+        The input coordinates can either be floats or NumPy arrays of values. If both
+        input coordinates are floats, the output will be a tuple of floats. If either of
+        the input coordinates are arrays, the inputs will be `broadcast together
+        <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_ and a tuple of
+        NumPy arrays will be returned.
 
         Args:
             lon: Planetographic longitude.
@@ -2622,13 +2628,26 @@ class Body(BodyBase):
         Returns:
             `(lon_centric, lat_centric)` tuple of planetocentric coordinates.
         """
+        return self._maybe_transform_as_arrays(
+            self._graphic2centric_lonlat, lon, lat, alt=alt
+        )
+
+    def _graphic2centric_lonlat(
+        self, lon: float, lat: float, *, alt: float
+    ) -> tuple[float, float]:
         return self._targvec2lonlat_centric(self.lonlat2targvec(lon, lat, alt=alt))
 
     def centric2graphic_lonlat(
-        self, lon_centric: float, lat_centric: float, *, alt: float = 0.0
-    ) -> tuple[float, float]:
+        self, lon_centric: FloatOrArray, lat_centric: FloatOrArray, *, alt: float = 0.0
+    ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert planetocentric longitude/latitude to planetographic.
+
+        The input coordinates can either be floats or NumPy arrays of values. If both
+        input coordinates are floats, the output will be a tuple of floats. If either of
+        the input coordinates are arrays, the inputs will be `broadcast together
+        <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_ and a tuple of
+        NumPy arrays will be returned.
 
         Args:
             lon_centric: Planetocentric longitude.
@@ -2638,6 +2657,13 @@ class Body(BodyBase):
         Returns:
             `(lon, lat)` tuple of planetographic coordinates.
         """
+        return self._maybe_transform_as_arrays(
+            self._centric2graphic_lonlat, lon_centric, lat_centric, alt=alt
+        )
+
+    def _centric2graphic_lonlat(
+        self, lon_centric: float, lat_centric: float, *, alt: float
+    ) -> tuple[float, float]:
         if not (math.isfinite(lon_centric) and math.isfinite(lat_centric)):
             return np.nan, np.nan
         targvecs = spice.latsrf(

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1956,14 +1956,25 @@ class TestBody(common_testing.BaseTestCase):
             [(0, -90), (0, -90)],
             [(90, 0), (-90, 0)],
             [(123.4, 56.789), (-123.4, 53.17999536010973)],
+            [
+                (array([1.0, 2.0, 3.0, nan]), array([40.0, 50.0, 60.0, nan])),
+                (
+                    array([-1.0, -2.0, -3.0, nan]),
+                    array([36.26969371, 46.18216311, 56.56575448, nan]),
+                ),
+            ],
         ]
         for graphic, centric in pairs:
             with self.subTest(graphic):
-                self.assertTrue(
-                    np.allclose(self.body.graphic2centric_lonlat(*graphic), centric)
+                self.assertArraysClose(
+                    self.body.graphic2centric_lonlat(*graphic),
+                    centric,
+                    equal_nan=True,
                 )
-                self.assertTrue(
-                    np.allclose(self.body.centric2graphic_lonlat(*centric), graphic)
+                self.assertArraysClose(
+                    self.body.centric2graphic_lonlat(*centric),
+                    graphic,
+                    equal_nan=True,
                 )
 
         pairs = [


### PR DESCRIPTION
Transformations between planetographic and planteocentric longitude/latitude coordinates can now accept arrays, in addition to floats. This is a direct continuation of the work in #370.

Closes #374

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.