### PR TITLE
Add `terminator_lonlat` and `limb_lonlat` methods to get terminator and limb longitude/latitude coordinate arrays

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2228,6 +2228,64 @@ class Body(BodyBase):
         Returns:
             `(ra, dec)` tuple of RA/Dec coordinate arrays.
         """
+        return self._targvec_arr2radec_arrs(
+            self._terminator_targvec(
+                npts=npts,
+                only_visible=only_visible,
+                close_loop=close_loop,
+                alt=alt,
+                method=method,
+                corloc=corloc,
+            )
+        )
+
+    def terminator_lonlat(
+        self,
+        npts: int = 360,
+        *,
+        only_visible: bool = False,
+        close_loop: bool = True,
+        alt: float = 0.0,
+        method: str = 'UMBRAL/TANGENT/ELLIPSOID',
+        corloc: str = 'ELLIPSOID TERMINATOR',
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate the Lon/Lat coordinates of the terminator (line between day and night)
+        on the target body.
+
+        Args:
+            npts: Number of points in generated terminator.
+            only_visible: Toggle only returning visible part of terminator.
+            alt: Altitude adjustment to the surface of the target body in km.
+            close_loop: If True, passes coordinate arrays through :func:`close_loop`
+                (e.g. to enable nicer plotting).
+            method, corloc: Passed to SPICE function.
+
+        Returns:
+            `(lon, lat)` tuple of Lon/Lat coordinate arrays.
+        """
+        # XXX test
+        targvecs = self._terminator_targvec(
+            npts=npts,
+            only_visible=only_visible,
+            close_loop=close_loop,
+            alt=alt,
+            method=method,
+            corloc=corloc,
+        )
+        lons, lats = zip(*(self.targvec2lonlat(targvec) for targvec in targvecs))
+        return np.array(lons), np.array(lats)
+
+    def _terminator_targvec(
+        self,
+        *,
+        npts: int,
+        only_visible: bool,
+        close_loop: bool,
+        alt: float,
+        method: str,
+        corloc: str,
+    ) -> np.ndarray:
         with _AdjustedSurfaceAltitude(self, alt):
             refvec = [0, 0, 1]
             rolstp = 2 * np.pi / npts
@@ -2249,15 +2307,20 @@ class Body(BodyBase):
             )
             if close_loop:
                 targvec_arr = self.close_loop(targvec_arr)
-            ra, dec = self._targvec_arr2radec_arrs(
-                targvec_arr,
-                condition_func=(
-                    (lambda t: self._test_if_targvec_visible(t, on_surface=True))
-                    if only_visible
-                    else None
-                ),
-            )
-            return ra, dec
+            if only_visible:
+                targvec_arr = np.array(
+                    [
+                        (
+                            targvec
+                            if self._test_if_targvec_visible(
+                                targvec, on_surface=alt == 0.0
+                            )
+                            else np.array([np.nan, np.nan, np.nan])
+                        )
+                        for targvec in targvec_arr
+                    ]
+                )
+            return targvec_arr
 
     def _test_if_targvec_illuminated(self, targvec: np.ndarray) -> bool:
         phase, incdnc, emissn, visibl, lit = self._illumf_from_targvec_radians(targvec)

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -1868,7 +1868,6 @@ class Body(BodyBase):
         Returns:
             `(lon, lat)` tuple of coordinate arrays.
         """
-        # XXX test
         with _AdjustedSurfaceAltitude(self, alt):
             lons, lats = zip(
                 *(
@@ -2285,7 +2284,6 @@ class Body(BodyBase):
         Returns:
             `(lon, lat)` tuple of Lon/Lat coordinate arrays.
         """
-        # XXX test
         targvecs = self._terminator_targvec(
             npts=npts,
             only_visible=only_visible,

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -1857,6 +1857,27 @@ class Body(BodyBase):
                     dec_day[idx] = np.nan
             return ra_day, dec_day, ra_night, dec_night
 
+    def limb_lonlat(self, alt: float = 0.0, **kwargs) -> tuple[np.ndarray, np.ndarray]:
+        """
+        Calculate the Lon/Lat coordinates of the target body's limb.
+
+        Args:
+            npts: Number of points in the generated limb.
+            alt: Altitude of the limb above the surface of the target body, in km.
+
+        Returns:
+            `(lon, lat)` tuple of coordinate arrays.
+        """
+        # XXX test
+        with _AdjustedSurfaceAltitude(self, alt):
+            lons, lats = zip(
+                *(
+                    self.targvec2lonlat(targvec)
+                    for targvec in self._limb_targvec(**kwargs)
+                )
+            )
+            return np.array(lons), np.array(lats)
+
     def limb_coordinates_from_radec(
         self, ra: float, dec: float, *, alt: float = 0.0
     ) -> tuple[float, float, float]:

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -1221,6 +1221,33 @@ class TestBody(common_testing.BaseTestCase):
             )
         )
 
+    def test_limb_lonlat(self):
+        self.assertArraysClose(
+            self.body.limb_lonlat(npts=5),
+            (
+                array(
+                    [
+                        153.1234683,
+                        242.11517437,
+                        247.35606526,
+                        58.89081584,
+                        64.1317418,
+                        153.1234683,
+                    ]
+                ),
+                array(
+                    [
+                        87.29379713,
+                        20.35346551,
+                        -57.46299289,
+                        -57.46299289,
+                        20.35346551,
+                        87.29379713,
+                    ]
+                ),
+            ),
+        )
+
     def test_limb_radec_by_illumination(self):
         self.assertTrue(
             np.allclose(
@@ -1419,6 +1446,42 @@ class TestBody(common_testing.BaseTestCase):
                 (array([nan, nan, 196.36713568]), array([nan, nan, -5.56628042])),
                 equal_nan=True,
             )
+        )
+
+    def test_terminator_lonlat(self):
+        self.assertArraysClose(
+            self.body.terminator_lonlat(npts=5),
+            (
+                array(
+                    [
+                        163.44532164,
+                        252.60875833,
+                        257.26193719,
+                        69.62871003,
+                        74.2818866,
+                        163.44532164,
+                    ]
+                ),
+                array(
+                    [
+                        87.66650962,
+                        20.36259847,
+                        -57.48337047,
+                        -57.48337047,
+                        20.36259847,
+                        87.66650962,
+                    ]
+                ),
+            ),
+            equal_nan=True,
+        )
+        self.assertArraysClose(
+            self.body.terminator_lonlat(npts=5, only_visible=True),
+            (
+                array([nan, nan, nan, 69.62871003, 74.2818866, nan]),
+                array([nan, nan, nan, -57.48337047, 20.36259847, nan]),
+            ),
+            equal_nan=True,
         )
 
     def test_if_lonlat_illuminated(self):


### PR DESCRIPTION
Added `terminator_lonlat` and `limb_lonlat` to generate arrays of longitude and latitude coordinates for the terminator and limb respectively. These are equivalents to the already-existing `terminator_radec` and `limb_radec` methods that generate RA/Dec coordinate arrays. The only difference is that the default value of `only_visible` is `True` for `terminator_radec`, but `False` for `terminator_lonlat`, as the lon/lat arrays are less directly linked to the observer's perspective.

These new methods are mainly useful when plotting the limb and terminator lines on mapped data.

Closes #376

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.