### PR TITLE
Fix 0.5px offset in the disc location produced by `BodyXY.centre_disc`

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -703,11 +703,11 @@ class BodyXY(Body):
 
         This adjusts `x0` and `y0` so that they lie in the centre of the image, and `r0`
         is adjusted so that the disc fills 90% of the shortest side of the image. For
-        example, if `nx = 20` and `ny = 30`, then `x0` will be set to 10, `y0` will be
+        example, if `nx = 21` and `ny = 31`, then `x0` will be set to 10, `y0` will be
         set to 15 and `r0` will be set to 9. The rotation of the disc is unchanged.
         """
-        self.set_x0(self._nx / 2)
-        self.set_y0(self._ny / 2)
+        self.set_x0((self._nx - 1) / 2)
+        self.set_y0((self._ny - 1) / 2)
         self.set_r0(0.9 * (min(self.get_x0(), self.get_y0())))
         self.set_disc_method('centre_disc')
 

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -475,7 +475,7 @@ class TestBodyXY(common_testing.BaseTestCase):
     def test_centre_disc(self):
         self.body.set_disc_params(0, 0, 1, 0)
         self.body.centre_disc()
-        self.assertEqual(self.body.get_disc_params(), (7.5, 5.0, 4.5, 0.0))
+        self.assertEqual(self.body.get_disc_params(), (7.0, 4.5, 4.05, 0.0))
         self.assertEqual(self.body.get_disc_method(), 'centre_disc')
 
     def test_img_size(self):
@@ -538,6 +538,7 @@ class TestBodyXY(common_testing.BaseTestCase):
         )
 
     def test_img_limits(self):
+        self.body.set_disc_params(7.5, 5.0, 4.5, 0.0)
         self.assertEqual(
             self.body.get_img_limits_xy(),
             (
@@ -674,6 +675,8 @@ class TestBodyXY(common_testing.BaseTestCase):
 
     @patch('matplotlib.pyplot.show')
     def test_plot_wireframe(self, mock_show: MagicMock):
+        self.body.set_disc_params(7.5, 5.0, 4.5, 0.0)
+
         fig, ax = plt.subplots()
         self.body.plot_wireframe_xy(ax=ax)
         self.assertEqual(len(ax.get_lines()), 21)


### PR DESCRIPTION
Corrected the implementation of `center_disc` so that the body's disc is actually centred in the image. Previously, there was a 0.5px offset in both the `x0` and `y0` coordinates, so that the disc was noticeably not centred for very small images.

Old version in red, new in black:
![image](https://github.com/user-attachments/assets/0e20ba1d-2ab6-4732-86f6-ff6b237f5d65)

Closes #384


### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.