### PR TITLE
Automatically update matplotlib transform involving `xy` coordinates when any disc parameters are changed

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -337,10 +337,6 @@ class BodyXY(Body):
         other.set_disc_method(self.get_disc_method())
         # set_img_size is covered by nx, ny in _get_kwargs, so would be redundant here
 
-    def _clear_cache(self) -> None:
-        super()._clear_cache()
-        self.update_transform()
-
     # Coordinate transformations
     @_cache_clearable_result
     def _get_xy2angular_matrix(self) -> np.ndarray:
@@ -631,6 +627,10 @@ class BodyXY(Body):
         return self._obsvec_norm2targvec(self._xy2obsvec_norm(x, y))
 
     # Interface
+    def _invalidate_disc_parameters(self) -> None:
+        self._clear_cache()
+        self.update_transform()
+
     def set_disc_params(
         self,
         x0: float | None = None,
@@ -726,7 +726,7 @@ class BodyXY(Body):
         if not math.isfinite(x0):
             raise ValueError('x0 must be finite')
         self._x0 = float(x0)
-        self._clear_cache()
+        self._invalidate_disc_parameters()
 
     def get_x0(self) -> float:
         """
@@ -746,7 +746,7 @@ class BodyXY(Body):
         if not math.isfinite(y0):
             raise ValueError('y0 must be finite')
         self._y0 = float(y0)
-        self._clear_cache()
+        self._invalidate_disc_parameters()
 
     def get_y0(self) -> float:
         """
@@ -768,7 +768,7 @@ class BodyXY(Body):
         if not r0 > 0:
             raise ValueError('r0 must be greater than zero')
         self._r0 = float(r0)
-        self._clear_cache()
+        self._invalidate_disc_parameters()
 
     def get_r0(self) -> float:
         """
@@ -779,7 +779,7 @@ class BodyXY(Body):
 
     def _set_rotation_radians(self, rotation: float) -> None:
         self._rotation_radians = float(rotation % (2 * np.pi))
-        self._clear_cache()
+        self._invalidate_disc_parameters()
 
     def _get_rotation_radians(self) -> float:
         return self._rotation_radians

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -252,10 +252,6 @@ class BodyXY(Body):
         self.set_disc_method('default')
         self._default_disc_method = 'manual'
 
-        if self._nx > 0 and self._ny > 0:
-            # centre disc if dimensions provided
-            self.centre_disc()
-
         self._mpl_transform_xy2angular_fixed: matplotlib.transforms.Affine2D | None = (
             None
         )
@@ -264,6 +260,10 @@ class BodyXY(Body):
         )
         self.backplanes = {}
         self._register_default_backplanes()
+
+        if self._nx > 0 and self._ny > 0:
+            # centre disc if dimensions provided
+            self.centre_disc()
 
     @classmethod
     def from_body(
@@ -336,6 +336,10 @@ class BodyXY(Body):
         other.set_disc_params(*self.get_disc_params())
         other.set_disc_method(self.get_disc_method())
         # set_img_size is covered by nx, ny in _get_kwargs, so would be redundant here
+
+    def _clear_cache(self) -> None:
+        super()._clear_cache()
+        self.update_transform()
 
     # Coordinate transformations
     @_cache_clearable_result
@@ -1097,14 +1101,41 @@ class BodyXY(Body):
         coordinates. ::
 
             # Plot an observed image on an RA/Dec axis with a wireframe of the target
-            ax = obs.plot_wireframe_radec()
+            ax = body.plot_wireframe_radec()
             ax.autoscale_view()
             ax.autoscale(False) # Prevent imshow breaking autoscale
             ax.imshow(
                 img,
                 origin='lower',
-                transform=obs.matplotlib_xy2radec_transform(ax),
+                transform=body.matplotlib_xy2radec_transform(ax),
                 )
+
+        .. note::
+            Matplotlib transformations involving `xy` coordinates are mutable, and will
+            be automatically updated whenever the disc parameters are changed. For
+            example, in the following code, the plotted image will use the `x0 = 10`
+            value that is set after the transform is used: ::
+
+                # ...
+                ax.imshow(
+                    img,
+                    origin='lower',
+                    transform=body.matplotlib_xy2radec_transform(ax),
+                    )
+                body.set_x0(10)
+                plt.show()
+
+            If you want to 'fix' the transform to a specific set of disc parameters, you
+            can use the transform's `frozen()` method to create a new transform that
+            will not be updated when the disc parameters change: ::
+
+                # ...
+                ax.imshow(
+                    img,
+                    origin='lower',
+                    transform=body.matplotlib_xy2radec_transform(ax).frozen(),
+                    )
+                # ...
 
         See :func:`Body.matplotlib_radec2km_transform` for more details and notes on
         limitations of these linear transformations.
@@ -1178,6 +1209,11 @@ class BodyXY(Body):
         Update the matplotlib transformations involving `xy` coordinates (e.g.
         :func:`matplotlib_radec2xy_transform`) to use the latest disc parameter
         values `(x0, y0, r0, rotation)`.
+
+        .. versionchanged:: ?.?.?
+            The transformations are now updated automatically whenever the disc
+            parameters are changed, so is generally no longer needed to be called
+            manually.
         """
         self._get_matplotlib_xy2angular_fixed_transform().set_matrix(
             self._get_xy2angular_matrix()

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -1899,13 +1899,26 @@ class TestBodyXY(common_testing.BaseTestCase):
         ]:
             with self.subTest(transform_method=transform_method):
                 transform = transform_method()
-                self.body.set_disc_params(10, 9, 8, 7)
-                self.body.update_transform()
-                m1 = transform.get_matrix()
                 self.body.set_disc_params(1.2, 3.4, 5.6, 178.9)
-                self.assertTrue(np.array_equal(m1, transform.get_matrix()))
-                self.body.update_transform()
-                self.assertFalse(np.array_equal(m1, transform.get_matrix()))
+                m0 = transform.get_matrix()
+
+                self.body.set_disc_params(10, 9, 8, 7)
+                m1 = transform.get_matrix()
+                self.assertFalse(np.array_equal(m0, m1))
+
+                self.body.set_disc_params(1.2, 3.4, 5.6, 178.9)
+                self.assertArraysEqual(m0, transform.get_matrix())
+                self.body._clear_cache()
+                self.assertArraysEqual(m0, transform.get_matrix())
+
+                # avoid auto update with set methods
+                self.body._x0 = 10.0
+                self.body._y0 = 9.0
+                self.body._r0 = 8.0
+                self.body._rotation_radians = float(np.deg2rad(7.0) % (2 * np.pi))
+                self.assertArraysEqual(m0, transform.get_matrix())
+                self.body._clear_cache()
+                self.assertArraysEqual(m1, transform.get_matrix())
 
         # Test passive update when getting 'new' transform
         # https://github.com/ortk95/planetmapper/issues/310

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -260,7 +260,7 @@ class TestBodyXY(common_testing.BaseTestCase):
             with self.subTest(fn.__name__):
                 self.body._cache[' test '] = None
                 fn(np.random.rand())
-                self.assertEqual(len(self.body._cache), 0)
+                self.assertNotIn(' test ', self.body._cache)
 
         self.body._stable_cache.clear()
         self.body.get_emission_angle_map(degree_interval=90)
@@ -1908,7 +1908,7 @@ class TestBodyXY(common_testing.BaseTestCase):
 
                 self.body.set_disc_params(1.2, 3.4, 5.6, 178.9)
                 self.assertArraysEqual(m0, transform.get_matrix())
-                self.body._clear_cache()
+                self.body._invalidate_disc_parameters()
                 self.assertArraysEqual(m0, transform.get_matrix())
 
                 # avoid auto update with set methods
@@ -1917,7 +1917,7 @@ class TestBodyXY(common_testing.BaseTestCase):
                 self.body._r0 = 8.0
                 self.body._rotation_radians = float(np.deg2rad(7.0) % (2 * np.pi))
                 self.assertArraysEqual(m0, transform.get_matrix())
-                self.body._clear_cache()
+                self.body._invalidate_disc_parameters()
                 self.assertArraysEqual(m1, transform.get_matrix())
 
         # Test passive update when getting 'new' transform


### PR DESCRIPTION
Previously, the matplotlib transforms involving `xy` coordinates could end using old values if disc parameters were changed without also calling `update_transform`. Now, the transforms are automatically updated whenever any disc parameters are changed, ensuring that the transforms should always be consistent with the current disc parameters.

Also updated the documentation about the mutable nature of the transforms, and how to use their `transform.frozen()` method to freeze the transform if needed.

Closes #389 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.