### PR TITLE
Add method to get wavelength array from an Observation's FITS Header, and add wavelength label to GUI settings tab

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1434,7 +1434,6 @@ class BodyXY(Body):
         cleaned[bad] = median
         # Fix bad pixels that have neighbouring good pixels by replacing them with the
         # mean of the surrounding 3x3 good pixels.
-        # pylint: disable-next=invalid-unary-operand-type
         to_fix = bad & ~scipy.ndimage.uniform_filter(bad, size=3)  #  type: ignore
         for i, j in np.argwhere(to_fix):
             cleaned[i, j] = np.nanmean(

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -160,6 +160,10 @@ class GUI:
         self._popups: list[Popup] = []
 
         self._observation: Observation | None = None
+        self._observation_wavelengths: np.ndarray | None = None
+        self._observation_wavelengths_fmt = 'f'
+        self._observation_wavelengths_unit = ''
+
         self.step_size = 1
 
         self.click_locations: list[tuple[float, float]] = []
@@ -376,6 +380,27 @@ class GUI:
 
         self.click_locations = []
         self.clear_click_location()
+
+        try:
+            self._observation_wavelengths = (
+                self.get_observation().get_wavelengths_from_header()
+            )
+            # Get an appropriate number of decimal places to represent wavelength steps
+            decimals = -np.log10(np.nanmean(np.diff(self._observation_wavelengths)))
+            if np.isfinite(decimals):
+                decimals = int(max(1, decimals + 0.5)) + 1
+                self._observation_wavelengths_fmt = f'.{decimals}f'
+            else:
+                self._observation_wavelengths_fmt = 'f'
+            self._observation_wavelengths_unit = str(
+                self.get_observation().header.get('CUNIT3', '')
+            ).strip()
+            if self._observation_wavelengths_unit:
+                self._observation_wavelengths_unit = (
+                    ' ' + self._observation_wavelengths_unit
+                )
+        except utils.GetWavelengthsError:
+            self._observation_wavelengths = None
 
     def get_observation(self) -> Observation:
         if self._observation is None:
@@ -2748,6 +2773,7 @@ class ArtistSetting(Popup, ABC):
 
 class PlotImageSetting(ArtistSetting):
     REPLOT_DELAY_MS = 100
+    SLIDER_DELAY_MS = 10
 
     def __init__(
         self,
@@ -2791,6 +2817,12 @@ class PlotImageSetting(ArtistSetting):
         )
         self.wavelength_slider.pack(fill='x')
 
+        self.single_wavelength_label = ttk.Label(
+            self.tools_frame,
+            justify='center',
+        )
+        self.single_wavelength_label.pack()
+
         self.enabled.trace_add('write', self.update_tool_ui_state)
         self.single_wavelength_enabled.trace_add(
             'write', self.on_single_wavelength_checkbutton_change
@@ -2827,16 +2859,32 @@ class PlotImageSetting(ArtistSetting):
                 self.single_wavelength_enabled.set(1)
 
         self.gui.plot_settings['_']['image_idx_single'] = wavelength_idx
-        self.schedule_replot()
 
-    def schedule_replot(self, skip_full_delay: bool = False) -> None:
         self.gui.add_delayed_action(
-            'update_only_image',
+            'set_slider_label',
+            self.SLIDER_DELAY_MS,
+            self.set_slider_label,
+        )
+        self.schedule_replot(set_slider=False)
+
+    def schedule_replot(
+        self, skip_full_delay: bool = False, set_slider: bool = True
+    ) -> None:
+        self.gui.add_delayed_action(
+            'do_replot',
             1 if skip_full_delay else self.REPLOT_DELAY_MS,
-            self.gui.update_only_image,
+            self.do_replot if set_slider else self.do_replot_no_slider,
         )
 
-    def update_tool_ui_state(self, *_) -> None:
+    def do_replot_no_slider(self):
+        self.update_tool_ui_state(set_slider=False)
+        self.gui.update_only_image()
+
+    def do_replot(self):
+        self.update_tool_ui_state()
+        self.gui.update_only_image()
+
+    def update_tool_ui_state(self, *_, set_slider: bool = True) -> None:
         self.in_tool_updating_state = True
         try:
             general_settings = self.gui.plot_settings['_']
@@ -2849,17 +2897,41 @@ class PlotImageSetting(ArtistSetting):
             wavelength_idx = int(general_settings.setdefault('image_idx_single', 0))
 
             self.single_wavelength_enabled.set(int(is_single_wavelength))
-            self.wavelength_variable.set(wavelength_idx)
+            if set_slider:
+                self.wavelength_variable.set(wavelength_idx)
 
             self.single_wavelength_checkbutton.configure(
                 state='normal' if enable else 'disable',
             )
-            self.wavelength_slider.configure(
-                to=n_wavelengths - 1,
-                state='normal' if enable else 'disable',
-            )
+            if set_slider:
+                self.wavelength_slider.configure(
+                    to=n_wavelengths - 1,
+                    state='normal' if enable else 'disable',
+                )
+            self.set_slider_label()
         finally:
             self.in_tool_updating_state = False
+
+    def set_slider_label(self):
+        general_settings = self.gui.plot_settings['_']
+        image_mode = general_settings.setdefault('image_mode', 'single')
+        if image_mode == 'single':
+            wavelength_idx = int(general_settings.setdefault('image_idx_single', 0))
+            if self.gui._observation_wavelengths is not None:
+                value_s = f' ({self.gui._observation_wavelengths[wavelength_idx]:{self.gui._observation_wavelengths_fmt}}{self.gui._observation_wavelengths_unit})'
+            self.single_wavelength_label.configure(
+                text=f'{wavelength_idx}{value_s}',
+                foreground='black',
+            )
+        else:
+            self.single_wavelength_label.configure(
+                text=(
+                    'Showing sum of all wavelengths'
+                    if image_mode == 'sum'
+                    else 'Showing RGB composite'
+                ),
+                foreground='gray50',
+            )
 
     def make_menu(self) -> None:
         settings = self.gui.plot_settings[self.key]

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -2919,6 +2919,8 @@ class PlotImageSetting(ArtistSetting):
             wavelength_idx = int(general_settings.setdefault('image_idx_single', 0))
             if self.gui._observation_wavelengths is not None:
                 value_s = f' ({self.gui._observation_wavelengths[wavelength_idx]:{self.gui._observation_wavelengths_fmt}}{self.gui._observation_wavelengths_unit})'
+            else:
+                value_s = ''
             self.single_wavelength_label.configure(
                 text=f'{wavelength_idx}{value_s}',
                 foreground='black',

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -351,7 +351,7 @@ class Observation(BodyXY):
         This uses the NAXIS3, CRVAL3, CDELT3 (or CD3_3) and CRPIX3 keywords to generate
         the wavelengths. If `check_ctype` is `True`, then the CTYPE3 keyword is also
         checked to ensure it is `'WAVE'`. If the Header does not contain the necessary
-        information to construct a wavelength array, then a 
+        information to construct a wavelength array, then a
         :class:`planetmapper.utils.GetWavelengthsError` is raised.
 
         See :func:`planetmapper.utils.generate_wavelengths_from_header` for more
@@ -359,11 +359,11 @@ class Observation(BodyXY):
 
         Args:
             check_ctype: Check that the CTYPE3 keyword is `'WAVE'`.
-        
+
         Returns:
             Wavelength array for the spectral cube. This will have the same length as
             the third axis of the data cube.
-        
+
         Raises:
             GetWavelengthsError: if the Header does not contain the necessary
                 information to construct a wavelength array.

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -368,7 +368,6 @@ class Observation(BodyXY):
             GetWavelengthsError: if the Header does not contain the necessary
                 information to construct a wavelength array.
         """
-        # XXX test
         return utils.generate_wavelengths_from_header(
             self.header, check_ctype=check_ctype
         )

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -342,6 +342,37 @@ class Observation(BodyXY):
         """:meta private:"""
         raise TypeError('Cannot set image size for Observation objects')
 
+    # Utils
+    def get_wavelengths_from_header(self, *, check_ctype: bool = True) -> np.ndarray:
+        """
+        Generate a wavelength array for a spectral cube, using metadata in the
+        observation's FITS Header.
+
+        This uses the NAXIS3, CRVAL3, CDELT3 (or CD3_3) and CRPIX3 keywords to generate
+        the wavelengths. If `check_ctype` is `True`, then the CTYPE3 keyword is also
+        checked to ensure it is `'WAVE'`. If the Header does not contain the necessary
+        information to construct a wavelength array, then a 
+        :class:`planetmapper.utils.GetWavelengthsError` is raised.
+
+        See :func:`planetmapper.utils.generate_wavelengths_from_header` for more
+        information.
+
+        Args:
+            check_ctype: Check that the CTYPE3 keyword is `'WAVE'`.
+        
+        Returns:
+            Wavelength array for the spectral cube. This will have the same length as
+            the third axis of the data cube.
+        
+        Raises:
+            GetWavelengthsError: if the Header does not contain the necessary
+                information to construct a wavelength array.
+        """
+        # XXX test
+        return utils.generate_wavelengths_from_header(
+            self.header, check_ctype=check_ctype
+        )
+
     # Auto disc id
     def disc_from_header(self) -> None:
         """

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -397,6 +397,48 @@ class TestObservation(common_testing.BaseTestCase):
         with self.assertRaises(TypeError):
             self.observation.set_img_size(2, 3)
 
+    def test_get_wavelengths_from_header(self):
+        observation = Observation(
+            data=np.ones((7, 6, 5)),
+            header=fits.Header(
+                {
+                    'CTYPE3': 'WAVE',
+                    'NAXIS3': 5,
+                    'CD3_3': 0.123,
+                    'CRVAL3': 0.456,
+                }
+            ),
+            target='Jupiter',
+            observer='hst',
+            utc='2005-01-01T00:00:00',
+        )
+        self.assertArraysClose(
+            observation.get_wavelengths_from_header(),
+            [0.456, 0.579, 0.702, 0.825, 0.948]
+        )
+
+        observation = Observation(
+            data=np.ones((7, 6, 5)),
+            header=fits.Header(
+                {
+                    'NAXIS3': 5,
+                    'CD3_3': 0.123,
+                    'CRVAL3': 0.456,
+                }
+            ),
+            target='Jupiter',
+            observer='hst',
+            utc='2005-01-01T00:00:00',
+        )
+        with self.assertRaises(planetmapper.utils.GetWavelengthsError):
+            observation.get_wavelengths_from_header()
+        self.assertArraysClose(
+            observation.get_wavelengths_from_header(check_ctype=False),
+            [0.456, 0.579, 0.702, 0.825, 0.948]
+        )
+
+
+
     def test_disc_from_header(self):
         with self.assertRaises(ValueError):
             self.observation.disc_from_header()

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -414,7 +414,7 @@ class TestObservation(common_testing.BaseTestCase):
         )
         self.assertArraysClose(
             observation.get_wavelengths_from_header(),
-            [0.456, 0.579, 0.702, 0.825, 0.948]
+            [0.456, 0.579, 0.702, 0.825, 0.948],
         )
 
         observation = Observation(
@@ -434,10 +434,8 @@ class TestObservation(common_testing.BaseTestCase):
             observation.get_wavelengths_from_header()
         self.assertArraysClose(
             observation.get_wavelengths_from_header(check_ctype=False),
-            [0.456, 0.579, 0.702, 0.825, 0.948]
+            [0.456, 0.579, 0.702, 0.825, 0.948],
         )
-
-
 
     def test_disc_from_header(self):
         with self.assertRaises(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,3 +177,74 @@ class TestUtils(common_testing.BaseTestCase):
         os.rmdir(path)
 
         utils.check_path('')
+
+    def test_generate_wavelengths_from_header(self):
+        pairs: list[tuple[dict, np.ndarray]] = [
+            (
+                {'CTYPE3': 'WAVE', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': 2, 'CDELT3': 1},
+                array([4.0, 5.0, 6.0, 7.0, 8.0]),
+            ),
+            (
+                {'CTYPE3': 'WAVE', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': 2, 'CD3_3': 1},
+                array([4.0, 5.0, 6.0, 7.0, 8.0]),
+            ),
+            (
+                {'CTYPE3': 'WAVE', 'NAXIS3': 3, 'CRVAL3': 1.234, 'CDELT3': -0.42},
+                array([1.234, 0.814, 0.394]),
+            ),
+        ]
+        for a, b in pairs:
+            with self.subTest(a):
+                wavelengths = utils.generate_wavelengths_from_header(a)
+                self.assertArraysClose(wavelengths, b)
+                self.assertIsInstance(wavelengths[0], float)
+            with self.subTest(a, header=True):
+                wavelengths = utils.generate_wavelengths_from_header(fits.Header(a))
+                self.assertArraysClose(wavelengths, b)
+                self.assertIsInstance(wavelengths[0], float)
+
+        error_inputs: list[dict] = [
+            {'CTYPE3': '?', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': 2, 'CDELT3': 1},
+            {'CTYPE3': 'WAVE', 'NAXIS3': None, 'CRPIX3': 3, 'CRVAL3': 2, 'CDELT3': 1},
+            {'CTYPE3': 'WAVE', 'NAXIS3': 5, 'CRPIX3': None, 'CRVAL3': 2, 'CDELT3': 1},
+            {'CTYPE3': 'WAVE', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': None, 'CDELT3': 1},
+            {
+                'CTYPE3': 'WAVE',
+                'NAXIS3': 5,
+                'CRPIX3': 3.1,
+                'CRVAL3': None,
+                'CDELT3': None,
+            },
+            {
+                'CTYPE3': 'WAVE',
+                'NAXIS3': 5,
+                'CRPIX3': 3.1,
+            },
+            {},
+        ]
+        for a in error_inputs:
+            with self.subTest(a):
+                with self.assertRaises(utils.GetWavelengthsError):
+                    utils.generate_wavelengths_from_header(a)
+                with self.assertRaises(utils.GetWavelengthsError):
+                    utils.generate_wavelengths_from_header(fits.Header(a))
+
+        with self.assertRaises(utils.GetWavelengthsError):
+            utils.generate_wavelengths_from_header(
+                {'CTYPE3': '?', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': 2, 'CDELT3': 1},
+            )
+        self.assertArraysClose(
+            utils.generate_wavelengths_from_header(
+                {'CTYPE3': '?', 'NAXIS3': 5, 'CRPIX3': 3, 'CRVAL3': 2, 'CDELT3': 1},
+                check_ctype=False,
+            ),
+            array([4.0, 5.0, 6.0, 7.0, 8.0]),
+        )
+        self.assertArraysClose(
+                        utils.generate_wavelengths_from_header(
+
+            {'CTYPE1': 'WAVE', 'NAXIS1': 5, 'CRPIX1': 3, 'CRVAL1': 2, 'CD1_1': 1},
+                        axis=1,
+                        ),
+            array([4.0, 5.0, 6.0, 7.0, 8.0]),
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -241,10 +241,9 @@ class TestUtils(common_testing.BaseTestCase):
             array([4.0, 5.0, 6.0, 7.0, 8.0]),
         )
         self.assertArraysClose(
-                        utils.generate_wavelengths_from_header(
-
-            {'CTYPE1': 'WAVE', 'NAXIS1': 5, 'CRPIX1': 3, 'CRVAL1': 2, 'CD1_1': 1},
-                        axis=1,
-                        ),
+            utils.generate_wavelengths_from_header(
+                {'CTYPE1': 'WAVE', 'NAXIS1': 5, 'CRPIX1': 3, 'CRVAL1': 2, 'CD1_1': 1},
+                axis=1,
+            ),
             array([4.0, 5.0, 6.0, 7.0, 8.0]),
         )


### PR DESCRIPTION
Added `Observation.get_wavelengths_from_header` method to get the wavelength array described by the observation's FITS Header (e.g. NAXIS3, CRVAL3, CDELT3 and CRPIX3 keywords). If the header does not contain the necessary information to construct a wavelength array, then this method will raise an exception.

This is implemented using a new `utils.generate_wavelengths_from_header` function that takes a FITS Header (or dictionary), and attempts to construct a wavelength array for it. The method to construct the wavelength array is based on the example code in the JWST documentation: https://jwst-docs.stsci.edu/jwst-calibration-status/miri-calibration-status/miri-mrs-calibration-status.

Also added a wavelength label to the "Settings" tab of the GUI, which uses this new wavelength information (if present) to display the currently plotted wavelength to the user. This should make it much easier to quickly select a wavelength of interest in the GUI.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/2d5a66e4-8de5-41bc-9891-93d817f51287">
 
<img width="912" alt="image" src="https://github.com/user-attachments/assets/bea5cf5f-a24e-4fce-8c33-e037908f1857">


Closes #372

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.