### PR TITLE
Check custom proj projection strings have the correct `+axis=...` parameter before mapping

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -2166,11 +2166,16 @@ class BodyXY(Body):
 
         Projections can also be specified by passing a proj projection string to the
         `projection` argument. If you are manually specifying a projection, you must
-        also specify `projection_x_coords` and `projection_y_coords` to provide the x
-        and y coordinates to project the data to. See
+        also at least `projection_x_coords` to provide the coordinates to project the
+        data to. Care should be taken to ensure that an appropriate `axis` parameter is
+        used - this should generally be `+axis=wnu` for bodies with positive west
+        coordinates, and `+axis=enu` for bodies with positive east coordinates (see
+        :attr:`Body.positive_longitude_direction`). See
         https://proj.org/operations/projections for a list of projections that can be
-        used. The provided projection string will be passed to `pyproj.CRS`.
-        :func:`create_proj_string` can be used to help build a projection string.
+        used, and more details on their parameters. The provided projection string will
+        be passed to `pyproj.CRS`. :func:`create_proj_string` can be used to help build
+        a projection string, and will automatically ensure that the correct axis
+        parameters are set.
 
         .. hint ::
 

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -1153,29 +1153,30 @@ class TestBodyXY(common_testing.BaseTestCase):
                 lat_coords=np.array([[1, 2, 3], [4, 5, 6]]),
             )
         with self.assertRaises(ValueError):
-            self.body.generate_map_coordinates('proj=ortho +R=1 +type=crs')
+            self.body.generate_map_coordinates('proj=ortho +R=1 +axis=wnu +type=crs')
         with self.assertRaises(ValueError):
             self.body.generate_map_coordinates(
-                'proj=ortho +R=1 +type=crs',
+                'proj=ortho +R=1 +axis=wnu +type=crs',
                 projection_x_coords=np.array([1, 2, 3]),
                 projection_y_coords=np.array([[1, 2, 3], [4, 5, 6]]),
             )
         with self.assertRaises(ValueError):
             self.body.generate_map_coordinates(
-                'proj=ortho +R=1 +type=crs',
+                'proj=ortho +R=1 +axis=wnu +type=crs',
                 projection_x_coords=np.array([[[1, 2, 3]]]),
             )
         with self.assertRaises(ValueError):
             self.body.generate_map_coordinates(
-                'proj=ortho +R=1 +type=crs',
+                'proj=ortho +R=1 +axis=wnu +type=crs',
                 projection_x_coords=np.array([[1, 2, 3]]),
                 projection_y_coords=np.array([[1, 2, 3], [4, 5, 6]]),
             )
         output_a = self.body.generate_map_coordinates(
-            '+proj=ortho +R=1 +type=crs', projection_x_coords=np.array([0, 0.25, 0.5])
+            '+proj=ortho +R=1 +axis=wnu +type=crs',
+            projection_x_coords=np.array([0, 0.25, 0.5]),
         )
         output_b = self.body.generate_map_coordinates(
-            '+proj=ortho +R=1 +type=crs',
+            '+proj=ortho +R=1 +axis=wnu +type=crs',
             projection_x_coords=np.array([0, 0.25, 0.5]),
             projection_y_coords=np.array([0, 0.25, 0.5]),
         )
@@ -1519,6 +1520,50 @@ class TestBodyXY(common_testing.BaseTestCase):
                 )
                 self.assertTrue(np.allclose(xx, xx_expected), msg=repr(xx))
                 self.assertTrue(np.allclose(yy, yy_expected), msg=repr(yy))
+
+        # Test proj strings
+        jupiter = BodyXY(
+            'Jupiter', observer='HST', utc='2005-01-01T00:00:00', nx=15, ny=10
+        )
+        earth = BodyXY('Earth', observer='Jupiter', utc='2005-01-01T00:00:00', sz=10)
+
+        with self.assertRaises(planetmapper.body_xy.ProjStringError):
+            jupiter.generate_map_coordinates(
+                '+proj=ortho +R=1 +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
+            earth.generate_map_coordinates(
+                '+proj=ortho +R=1 +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
+        jupiter.generate_map_coordinates(
+            '+proj=ortho +R=1 +axis=wnu +type=crs',
+            projection_x_coords=np.array([0, 0.25, 0.5]),
+        )
+        earth.generate_map_coordinates(
+            '+proj=ortho +R=1 +axis=enu +type=crs',
+            projection_x_coords=np.array([0, 0.25, 0.5]),
+        )
+        with self.assertRaises(planetmapper.body_xy.ProjStringError):
+            jupiter.generate_map_coordinates(
+                '+proj=ortho +R=1 +axis=enu +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
+        with self.assertRaises(planetmapper.body_xy.ProjStringError):
+            earth.generate_map_coordinates(
+                '+proj=ortho +R=1 +axis=wnu +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
+        with self.assertRaises(planetmapper.body_xy.ProjStringError):
+            jupiter.generate_map_coordinates(
+                '+proj=ortho +R=1 +axis=neu +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
+        with self.assertRaises(planetmapper.body_xy.ProjStringError):
+            earth.generate_map_coordinates(
+                '+proj=ortho +R=1 +axis=neu +type=crs',
+                projection_x_coords=np.array([0, 0.25, 0.5]),
+            )
 
     def test_create_proj_string(self):
         jupiter = BodyXY(


### PR DESCRIPTION
If a custom proj projection string is used when mapping, check the string's `+axis` parameter is consistent with the positive longitude direction of the body. I.e. positive west bodies should have `+axis=wnu` and positive east bodies should have `+axis=enu`. If the wrong `+axis` parameter is used, then the output map is likely to be flipped and therefore incorrect, so PlanetMapper now raises a `ProjStringError` exception if the positive longitude direction and `+axis` parameters are inconsistent.

Also updated relevant documentation to suggest using `create_proj_string`, which automatically generates the correct `+axis` parameter for the body.

Closes #397 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.