### PR TITLE
Add `planetmapper.run_gui()` function to allow the user interface be easily launched from a Python terminal

### DIFF
--- a/docs/user_interface.rst
+++ b/docs/user_interface.rst
@@ -3,23 +3,26 @@
 Graphical user interface
 ************************
 
-The user interface is a convenient and easy way to fit an observation, generate backplanes and map the observed data.
+The Graphical User Interface (GUI) is a convenient and easy way to fit an observation, generate backplanes and map the observed data.
 
 Starting the user interface
 ===========================
-The easiest way to run the PlanetMapper user interface is to simply type `planetmapper` in the command line. This will launch a new interactive window where you can choose observation files to open and fit. 
+The easiest way to run the PlanetMapper user interface is to simply type `planetmapper` in the command line (or alternatively, call the :func:`planetmapper.run_gui` Python function). This will launch a new interactive window where you can choose observation files to open and fit.
 
-You can create a user interface from a :class:`planetmapper.Observation` object using the  :func:`planetmapper.Observation.run_gui` function. This is mainly useful if you want to combine using a user interface to fit the observation with some Python code to e.g. run some additional analysis. This also gives you access to the full customisation offered by :class:`planetmapper.Observation`, allowing you to specify parameters such as `illumination_source` and `aberration_correction` which cannot be customised using the GUI alone.
-
-It is also possible to start a user interface directly using :func:`planetmapper.gui.GUI.run`, although the other two methods are generally more useful.
+You can also create a user interface from a :class:`planetmapper.Observation` object using the  :func:`planetmapper.Observation.run_gui` function. This is mainly useful if you want to combine using a user interface to fit the observation with some Python code to e.g. run some additional analysis. This also gives you access to the full customisation offered by :class:`planetmapper.Observation`, allowing you to specify parameters such as `illumination_source` and `aberration_correction` which cannot be customised using the GUI alone.
 
 
 Fitting an observation
 ======================
 .. note::
-    You can download the Europa data file used in these examples from the `PlanetMapper GitHub repository <https://github.com/ortk95/planetmapper/tree/main/examples/gui_data>`_.
+    You can download the Europa data file [#king2022]_ used in these examples from the `PlanetMapper GitHub repository <https://github.com/ortk95/planetmapper/tree/main/examples/gui_data>`_.
 
-To start, type `planetmapper` into a command line and press :kbd:`Enter`. This will open a window where you can choose a file to open:[#king2022]_
+To start, launch the PlanetMapper user interface from either the command line, or from within Python:
+
+- From an operating system command line: type `planetmapper` and press :kbd:`Enter`.
+- From a Python terminal (or within a Python script): import `planetmapper`, then run :func:`planetmapper.run_gui`.
+
+These will both open a window where you can then choose a file to open:
  
 .. image:: images/gui_open.png
     :width: 600
@@ -63,7 +66,7 @@ You can also use the :guilabel:`Settings` tab to mark points of interest to help
 Once you are happy with the fitting result, click :guilabel:`Save` at the top of the :guilabel:`Controls` tab. This will open a window where you can choose which files to output. You can customise which files to output (with the :guilabel:`Save navigated observation` and :guilabel:`Save mapped observation` checkboxes) and choose the filepath where these files will be saved.
 
 - The navigated observation is similar to the input file, with additional 'FITS backplanes' containing useful information such as the longitude/latitude coordinates for each pixel in the image. This file is generated using the function :func:`planetmapper.Observation.save_observation`.
-- The mapped observation produces a FITS file which contains (as the name suggests...) a mapped version of the observation. This map file will also contain the various useful backplanes. The degree interval option allows you to customise the size of the output map (e.g. degree interval=1 produces a map which is 180x360, degree interval=10 produces a map which is 18x36). This file is generated using the function :func:`planetmapper.Observation.save_mapped_observation`.
+- The mapped observation produces a FITS file which contains (as the name suggests...) a mapped version of the observation. This map file will also contain the various useful backplanes. The map projection and resolution of the output data can be fully customised. This file is generated using the function :func:`planetmapper.Observation.save_mapped_observation`.
 
 Once you click :guilabel:`Save`, your requested files will be generated and saved. Note that for larger files, this can take around a minute to complete as some of the coordinate conversion calculations are relatively complex.
 

--- a/planetmapper/__init__.py
+++ b/planetmapper/__init__.py
@@ -137,9 +137,11 @@ from .body import (
 )
 from .body_xy import Backplane, BodyXY, MapKwargs
 from .common import __author__, __description__, __license__, __url__, __version__
+from .gui import run_gui
 from .observation import Observation
 
 __all__ = [
+    'run_gui',
     'set_kernel_path',
     'get_kernel_path',
     'SpiceBase',

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -138,6 +138,25 @@ def _run_gui_from_cli(*args: str | None) -> None:
     gui.run()
 
 
+def run_gui(path: str | os.PathLike | None = None) -> None:
+    """
+    Launch the PlanetMapper Graphical User Interface (GUI) to fit observations.
+
+    This is the Python equivalent of running `planetmapper` from the command line.
+
+    Args:
+        path: Optionally specify a FITS file to open in the GUI. If this is provided,
+            the GUI will open with the observation from the FITS file loaded and ready
+            to fit. If not provided, you can select a file to open from the GUI.
+            Passed to the `path` argument of :class:`planetmapper.Observation`.
+    """
+    # XXX document
+    gui = GUI()
+    if path is not None:
+        gui.set_observation(Observation(path))
+    gui.run()
+
+
 class Quit(Exception):
     pass
 

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -142,7 +142,9 @@ def run_gui(path: str | os.PathLike | None = None) -> None:
     """
     Launch the PlanetMapper Graphical User Interface (GUI) to fit observations.
 
-    This is the Python equivalent of running `planetmapper` from the command line.
+    This is the Python equivalent of running `planetmapper` from the command line. See
+    :ref:`the user interface documentation <gui examples>` for more details about how to
+    use the GUI.
 
     Args:
         path: Optionally specify a FITS file to open in the GUI. If this is provided,
@@ -150,7 +152,6 @@ def run_gui(path: str | os.PathLike | None = None) -> None:
             to fit. If not provided, you can select a file to open from the GUI.
             Passed to the `path` argument of :class:`planetmapper.Observation`.
     """
-    # XXX document
     gui = GUI()
     if path is not None:
         gui.set_observation(Observation(path))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,8 +1,35 @@
+import os
 import unittest
+from unittest.mock import MagicMock, patch
 
 import common_testing
 
+import planetmapper
+import planetmapper.gui
 from planetmapper.gui import GUI
+
+
+class TestFunctions(common_testing.BaseTestCase):
+
+    @patch('planetmapper.gui.GUI', autospec=True)
+    def test_run_gui(self, mock_GUI: MagicMock):
+
+        mock_gui_instance = MagicMock()
+        mock_GUI.return_value = mock_gui_instance
+
+        planetmapper.gui.run_gui()
+        mock_GUI.assert_called_once_with()
+        mock_gui_instance.run.assert_called_once_with()
+        mock_gui_instance.set_observation.assert_not_called()
+
+        mock_GUI.reset_mock()
+        path = os.path.join(common_testing.DATA_PATH, 'inputs', 'test.fits')
+        planetmapper.gui.run_gui(path)
+        mock_GUI.assert_called_once_with()
+        mock_gui_instance.run.assert_called_once_with()
+        mock_gui_instance.set_observation.assert_called_once_with(
+            planetmapper.Observation(path)
+        )
 
 
 class TestGUI(common_testing.BaseTestCase):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -34,8 +34,16 @@ class TestInit(common_testing.BaseTestCase):
         )
 
     def test_all(self):
-        self.assertEqual(len(planetmapper.__all__), 18)  # ensure tests are up to date
+        """
+        Test that all submodules, classes and functions are imported correctly.
 
+        E.g. this tests that planetmapper.run_gui and planetmapper.gui.run_gui are the
+        same thing, then the actual functionality of the run_gui function is tested in
+        test_gui.py.
+        """
+        self.assertEqual(len(planetmapper.__all__), 19)  # ensure tests are up to date
+
+        self.assertIs(planetmapper.run_gui, planetmapper.gui.run_gui)
         self.assertIs(planetmapper.set_kernel_path, planetmapper.base.set_kernel_path)
         self.assertIs(planetmapper.get_kernel_path, planetmapper.base.get_kernel_path)
         self.assertIs(planetmapper.SpiceBase, planetmapper.base.SpiceBase)


### PR DESCRIPTION
Added new `planetmapper.run_gui()` method, which is a direct equivalent of running `planetmapper` from the an OS command line. This makes it much easier to launch the user interface from within Python code (e.g. in a script, an interactive terminal etc.).

Closes #400 


### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.