### PR TITLE
Make cached NumPy arrays read-only

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -87,6 +87,25 @@ As a temporary workaround, you can set the `PLANETMAPPER_USE_X11_FONT_BUGFIX` en
 This tells the PlanetMapper user interface to replace certain characters with ASCII equivalents (e.g. `↑` is replaced with `^`) which seems to prevent the use of the fonts which cause XQuartz to crash. Note that this will make the user interface slightly more ugly, but should not affect functionality. If you are still having issues after trying this workaround, you can `add a comment to the GitHub issue <https://github.com/ortk95/planetmapper/issues/145>`_.
 
 
+.. _readonly arrays:
+
+Read-only NumPy arrays
+======================
+Many PlanetMapper functions return read-only NumPy arrays (e.g. backplane methods like :func:`planetmapper.BodyXY.get_lon_img`). This prevents bugs caused by accidentally modifying cached data, but will cause an exception if you try to directly modify the array:
+
+::
+
+    ValueError: assignment destination is read-only
+
+To convert a read-only NumPy array to a writeable array, you can use the `copy` method:
+
+::
+
+    lon_img = body.get_lon_img().copy()
+
+This will create a copy of the array that you can safely modify, without affecting the original cached array.
+
+
 Wireframe plots appear warped or distorted
 ==========================================
 This is most likely to occur when using :func:`planetmapper.Body.plot_wireframe_radec` for a target located near the celestial pole (i.e. the target's declination is near 90° or -90°). The `plot can be distorted <https://github.com/ortk95/planetmapper/issues/323>`_ because spherical coordinates (like RA/Dec) are fundamentally impossible to represent perfectly in a 2D cartesian plot, with the distortion increasing at high declinations near the coordinate singularity at the celestial poles.

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -129,7 +129,6 @@ def _return_readonly_array(
     This is designed for use with caching decorators, as the cached array should not be
     mutable.
     """
-    # XXX document
 
     @functools.wraps(fn)
     def decorated(self: S, *args_in: P.args, **kwargs_in: P.kwargs) -> np.ndarray:

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -111,6 +111,33 @@ def _cache_stable_result(
     return decorated
 
 
+def _as_readonly_view(arr: np.ndarray) -> np.ndarray:
+    """
+    Return a read-only view of a numpy array.
+    """
+    out = arr.view()
+    out.setflags(write=False)
+    return out
+
+
+def _return_readonly_array(
+    fn: Callable[Concatenate[S, P], np.ndarray]
+) -> Callable[Concatenate[S, P], np.ndarray]:
+    """
+    Decorator to return a read-only numpy array by setting its writeable flag to False.
+
+    This is designed for use with caching decorators, as the cached array should not be
+    mutable.
+    """
+    # XXX document
+
+    @functools.wraps(fn)
+    def decorated(self: S, *args_in: P.args, **kwargs_in: P.kwargs) -> np.ndarray:
+        return _as_readonly_view(fn(self, *args_in, **kwargs_in))
+
+    return decorated
+
+
 def _add_help_note_to_spice_errors(fn: Callable[P, T]) -> Callable[P, T]:
     """
     Decorator to add help text to spice errors

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -2260,7 +2260,8 @@ class BodyXY(Body):
             object that can be used to transform between the two coordinate systems, and
             `info` is a dictionary containing the arguments used to build the map (e.g.
             for the default case this would be `{'projection': 'rectangular',
-            'degree_interval': 1, 'xlim': None, 'ylim': None}`).
+            'degree_interval': 1, 'xlim': None, 'ylim': None}`). The `lons`, `lats`,
+            `xx` and `yy` arrays are :ref:`read-only<readonly arrays>`.
 
         Raises:
             ProjStringError: If a custom proj projection string is used that has an
@@ -2378,7 +2379,6 @@ class BodyXY(Body):
 
         if alt != 0.0:
             info['alt'] = alt
-        # XXX test
         return (
             _as_readonly_view(lons),
             _as_readonly_view(lats),
@@ -2681,8 +2681,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetographic longitude value of each pixel in the
-            image. Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the planetographic
+            longitude value of each pixel in the image. Points off the disc have a value
+            of NaN.
         """
         return self._get_lonlat_img()[:, :, 0]
 
@@ -2692,7 +2693,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of planetographic longitude values.
+            :ref:`Read-only array<readonly arrays>` containing map of planetographic
+            longitude values.
         """
         return self._get_lonlat_map(**map_kwargs)[:, :, 0]
 
@@ -2701,8 +2703,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetographic latitude value of each pixel in the
-            image. Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the planetographic
+            latitude value of each pixel in the image. Points off the disc have a value
+            of NaN.
         """
         return self._get_lonlat_img()[:, :, 1]
 
@@ -2712,7 +2715,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of planetographic latitude values.
+            :ref:`Read-only array<readonly arrays>` containing map of planetographic
+            latitude values.
         """
         return self._get_lonlat_map(**map_kwargs)[:, :, 1]
 
@@ -2740,8 +2744,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetocentric longitude value of each pixel in the
-            image. Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the planetocentric
+            longitude value of each pixel in the image. Points off the disc have a value
+            of NaN.
         """
         return self._get_lonlat_centric_img()[:, :, 0]
 
@@ -2751,7 +2756,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of planetocentric longitude values.
+            :ref:`Read-only array<readonly arrays>` containing map of planetocentric
+            longitude values.
         """
         return self._get_lonlat_centric_map(**map_kwargs)[:, :, 0]
 
@@ -2760,8 +2766,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetocentric latitude value of each pixel in the
-            image. Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the planetocentric
+            latitude value of each pixel in the image. Points off the disc have a value
+            of NaN.
         """
         return self._get_lonlat_centric_img()[:, :, 1]
 
@@ -2771,7 +2778,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of planetocentric latitude values.
+            :ref:`Read-only array<readonly arrays>` containing map of planetocentric
+            latitude values.
         """
         return self._get_lonlat_centric_map(**map_kwargs)[:, :, 1]
 
@@ -2805,7 +2813,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the right ascension (RA) value of each pixel in the image.
+            :ref:`Read-only array<readonly arrays>` containing the right ascension (RA)
+            value of each pixel in the image.
         """
         return self._get_radec_img()[:, :, 0]
 
@@ -2815,8 +2824,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of right ascension values as viewed by the observer.
-            Locations which are not visible have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of right ascension
+            values as viewed by the observer. Locations which are not visible have a
+            value of NaN.
         """
         return self._get_radec_map(**map_kwargs)[:, :, 0]
 
@@ -2825,7 +2835,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the declination (Dec) value of each pixel in the image.
+            :ref:`Read-only array<readonly arrays>` containing the declination (Dec)
+            value of each pixel in the image.
         """
         return self._get_radec_img()[:, :, 1]
 
@@ -2835,8 +2846,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of declination values as viewed by the observer.
-            Locations which are not visible have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of declination values
+            as viewed by the observer. Locations which are not visible have a value of
+            NaN.
         """
         return self._get_radec_map(**map_kwargs)[:, :, 1]
 
@@ -2861,7 +2873,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the x pixel coordinate value of each pixel in the image.
+            :ref:`Read-only array<readonly arrays>` containing the x pixel coordinate
+            value of each pixel in the image.
         """
         out = self._make_empty_img()
         for y, x in self._iterate_image(out.shape):
@@ -2874,9 +2887,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the x pixel coordinates each location corresponds to
-            in the observation. Locations which are not visible or are not in the image
-            frame have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the x pixel
+            coordinates each location corresponds to in the observation. Locations which
+            are not visible or are not in the image frame have a value of NaN.
         """
         return self._get_xy_map(**map_kwargs)[:, :, 0]
 
@@ -2886,7 +2899,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the y pixel coordinate value of each pixel in the image.
+            :ref:`Read-only array<readonly arrays>` containing the y pixel coordinate
+            value of each pixel in the image.
         """
         out = self._make_empty_img()
         for y, x in self._iterate_image(out.shape):
@@ -2899,9 +2913,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the y pixel coordinates each location corresponds to
-            in the observation. Locations which are not visible or are not in the image
-            frame have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the y pixel
+            coordinates each location corresponds to in the observation. Locations which
+            are not visible or are not in the image frame have a value of NaN.
         """
         return self._get_xy_map(**map_kwargs)[:, :, 1]
 
@@ -2931,8 +2945,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the distance in target plane in km in the East-West
-            direction.
+            :ref:`Read-only array<readonly arrays>` containing the distance in target
+            plane in km in the East-West direction.
         """
         return self._get_km_xy_img()[:, :, 0]
 
@@ -2942,8 +2956,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the distance in target plane in km in the East-West
-            direction. Locations which are not visible have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the distance in
+            target plane in km in the East-West direction. Locations which are not
+            visible have a value of NaN.
         """
         return self._get_km_xy_map(**map_kwargs)[:, :, 0]
 
@@ -2952,8 +2967,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the distance in target plane in km in the North-South
-            direction.
+            :ref:`Read-only array<readonly arrays>` containing the distance in target
+            plane in km in the North-South direction.
         """
         return self._get_km_xy_img()[:, :, 1]
 
@@ -2963,8 +2978,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the distance in target plane in km in the
-            North-South direction. Locations which are not visible have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the distance in
+            target plane in km in the North-South direction. Locations which are not
+            visible have a value of NaN.
         """
         return self._get_km_xy_map(**map_kwargs)[:, :, 1]
 
@@ -2992,8 +3008,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the phase angle value of each pixel in the image. Points
-            off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the phase angle value of
+            each pixel in the image. Points off the disc have a value of NaN.
         """
         return self._get_illumination_gie_img()[:, :, 0]
 
@@ -3003,8 +3019,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the phase angle value at each point on the target's
-            surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the phase angle
+            value at each point on the target's surface.
         """
         return self._get_illumf_map(**map_kwargs)[:, :, 0]
 
@@ -3013,8 +3029,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the incidence angle value of each pixel in the image.
-            Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the incidence angle value
+            of each pixel in the image. Points off the disc have a value of NaN.
         """
         return self._get_illumination_gie_img()[:, :, 1]
 
@@ -3024,8 +3040,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the incidence angle value at each point on the
-            target's surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the incidence
+            angle value at each point on the target's surface.
         """
         return self._get_illumf_map(**map_kwargs)[:, :, 1]
 
@@ -3034,8 +3050,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the emission angle value of each pixel in the image. Points
-            off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the emission angle value
+            of each pixel in the image. Points off the disc have a value of NaN.
         """
         return self._get_illumination_gie_img()[:, :, 2]
 
@@ -3045,8 +3061,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the emission angle value at each point on the
-            target's surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the emission angle
+            value at each point on the target's surface.
         """
         return self._get_illumf_map(**map_kwargs)[:, :, 2]
 
@@ -3057,8 +3073,8 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the azimuth angle value of each pixel in the image. Points
-            off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the azimuth angle value
+            of each pixel in the image. Points off the disc have a value of NaN.
         """
         phase_radians = np.deg2rad(self._get_illumination_gie_img()[:, :, 0])
         incidence_radians = np.deg2rad(self._get_illumination_gie_img()[:, :, 1])
@@ -3080,8 +3096,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the azimuth angle value at each point on the
-            target's surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the azimuth angle
+            value at each point on the target's surface.
         """
         phase_radians = np.deg2rad(self._get_illumf_map(**map_kwargs)[:, :, 0])
         incidence_radians = np.deg2rad(self._get_illumf_map(**map_kwargs)[:, :, 1])
@@ -3102,9 +3118,10 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the local solar time value of each pixel in the image, as
-            calculated by :func:`Body.local_solar_time_from_lon`. Points off the disc
-            have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the local solar time
+            value of each pixel in the image, as calculated by
+            :func:`Body.local_solar_time_from_lon`. Points off the disc have a value of
+            NaN.
         """
         lon_img = self.get_lon_img()
         out = self._make_empty_img()
@@ -3124,8 +3141,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the local solar time at each point on the target's
-            surface, as calculated by :func:`Body.local_solar_time_from_lon`.
+            :ref:`Read-only array<readonly arrays>` containing map of the local solar
+            time at each point on the target's surface, as calculated by
+            :func:`Body.local_solar_time_from_lon`.
         """
         lon_map = self.get_lon_map(**map_kwargs)
         out = self._make_empty_map(**map_kwargs)
@@ -3180,8 +3198,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the observer-target distance in km of each pixel in the
-            image. Points off the disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the observer-target
+            distance in km of each pixel in the image. Points off the disc have a value
+            of NaN.
         """
         position_img, velocity_img, lt_img = self._get_state_imgs()
         return lt_img * self.speed_of_light()
@@ -3193,8 +3212,8 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the observer-target distance in km of each point on
-            the target's surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the
+            observer-target distance in km of each point on the target's surface.
         """
         position_map, velocity_map, lt_map = self._get_state_maps(**map_kwargs)
         return lt_map * self.speed_of_light()
@@ -3207,9 +3226,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the observer-target radial velocity in km/s of each pixel
-            in the image. Velocities towards the observer are negative. Points off the
-            disc have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the observer-target
+            radial velocity in km/s of each pixel in the image. Velocities towards the
+            observer are negative. Points off the disc have a value of NaN.
         """
         out = self._make_empty_img()
         position_img, velocity_img, lt_img = self._get_state_imgs()
@@ -3229,8 +3248,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the observer-target radial velocity in km/s of each
-            point on the target's surface.
+            :ref:`Read-only array<readonly arrays>` containing map of the
+            observer-target radial velocity in km/s of each point on the target's
+            surface.
         """
         out = self._make_empty_map(**map_kwargs)
         position_map, velocity_map, lt_map = self._get_state_maps(**map_kwargs)
@@ -3246,8 +3266,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the doppler factor for each pixel in the image, calculated
-            using :func:`SpiceBase.calculate_doppler_factor` on velocities from
+            :ref:`Read-only array<readonly arrays>` containing the doppler factor for
+            each pixel in the image, calculated using
+            :func:`SpiceBase.calculate_doppler_factor` on velocities from
             :func:`get_radial_velocity_img`. Points off the disc have a value of NaN.
         """
         return self.calculate_doppler_factor(self.get_radial_velocity_img())
@@ -3259,9 +3280,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the doppler factor of each point on the target's
-            surface. This is calculated using :func:`SpiceBase.calculate_doppler_factor`
-            on velocities from :func:`get_radial_velocity_map`.
+            :ref:`Read-only array<readonly arrays>` containing map of the doppler factor
+            of each point on the target's surface. This is calculated using
+            :func:`SpiceBase.calculate_doppler_factor` on velocities from
+            :func:`get_radial_velocity_map`.
         """
         return self.calculate_doppler_factor(self.get_radial_velocity_map(**map_kwargs))
 
@@ -3294,9 +3316,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetographic longitude of the point on the target's
-            limb that is closest to each pixel. See
-            :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing the planetographic
+            longitude of the point on the target's limb that is closest to each pixel.
+            See :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_imgs()[:, :, 0]
 
@@ -3306,9 +3328,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the planetographic longitude of the point on the
-            target's limb that is closest to each point on the target's surface (for the
-            observer). See :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing map of the planetographic
+            longitude of the point on the target's limb that is closest to each point on
+            the target's surface (for the observer). See
+            :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_maps(**map_kwargs)[:, :, 0]
 
@@ -3317,9 +3340,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the planetographic latitude of the point on the target's
-            limb that is closest to each pixel. See
-            :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing the planetographic
+            latitude of the point on the target's limb that is closest to each pixel.
+            See :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_imgs()[:, :, 1]
 
@@ -3329,9 +3352,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the planetographic latitude of the point on the
-            target's limb that is closest to each point on the target's surface (for the
-            observer). See :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing map of the planetographic
+            latitude of the point on the target's limb that is closest to each point on
+            the target's surface (for the observer). See
+            :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_maps(**map_kwargs)[:, :, 1]
 
@@ -3340,8 +3364,9 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the distance in km above the target's limb for each pixel.
-            See :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing the distance in km above
+            the target's limb for each pixel. See
+            :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_imgs()[:, :, 2]
 
@@ -3351,9 +3376,9 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the distance in km above the target's limb for each
-            point on the target's surface (for the observer). See
-            :func:`Body.limb_coordinates_from_radec` for more detail.
+            :ref:`Read-only array<readonly arrays>` containing map of the distance in km
+            above the target's limb for each point on the target's surface (for the
+            observer). See :func:`Body.limb_coordinates_from_radec` for more detail.
         """
         return self._get_limb_coordinate_maps(**map_kwargs)[:, :, 2]
 
@@ -3421,9 +3446,10 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the ring plane radius in km for each pixel in the image,
-            calculated using :func:`Body.ring_plane_coordinates`. Points of the ring
-            plane obscured by the target body have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the ring plane radius in
+            km for each pixel in the image, calculated using
+            :func:`Body.ring_plane_coordinates`. Points of the ring plane obscured by
+            the target body have a value of NaN.
         """
         return self._get_ring_plane_coordinate_imgs()[0]
 
@@ -3433,10 +3459,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the ring plane radius in km obscuring each point on
-            the target's surface, calculated using :func:`Body.ring_plane_coordinates`.
-            Points where the target body is unobscured by the ring plane have a value of
-            NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the ring plane
+            radius in km obscuring each point on the target's surface, calculated using
+            :func:`Body.ring_plane_coordinates`. Points where the target body is
+            unobscured by the ring plane have a value of NaN.
         """
         return self._get_ring_plane_coordinate_maps(**map_kwargs)[0]
 
@@ -3445,9 +3471,10 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the ring plane planetographic longitude in degrees for each
-            pixel in the image, calculated using :func:`Body.ring_plane_coordinates`.
-            Points of the ring plane obscured by the target body have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the ring plane
+            planetographic longitude in degrees for each pixel in the image, calculated
+            using :func:`Body.ring_plane_coordinates`. Points of the ring plane obscured
+            by the target body have a value of NaN.
         """
         return self._get_ring_plane_coordinate_imgs()[1]
 
@@ -3459,10 +3486,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the ring plane planetographic longitude in degrees
-            obscuring each point on the target's surface, calculated using
-            :func:`Body.ring_plane_coordinates`. Points where the target body is
-            unobscured by the ring plane have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the ring plane
+            planetographic longitude in degrees obscuring each point on the target's
+            surface, calculated using :func:`Body.ring_plane_coordinates`. Points where
+            the target body is unobscured by the ring plane have a value of NaN.
         """
         return self._get_ring_plane_coordinate_maps(**map_kwargs)[1]
 
@@ -3471,9 +3498,10 @@ class BodyXY(Body):
         See also :func:`get_backplane_img`.
 
         Returns:
-            Array containing the ring plane distance from the observer in km for each
-            pixel in the image, calculated using :func:`Body.ring_plane_coordinates`.
-            Points of the ring plane obscured by the target body have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing the ring plane distance
+            from the observer in km for each pixel in the image, calculated using
+            :func:`Body.ring_plane_coordinates`. Points of the ring plane obscured by
+            the target body have a value of NaN.
         """
         return self._get_ring_plane_coordinate_imgs()[2]
 
@@ -3485,10 +3513,10 @@ class BodyXY(Body):
         :func:`get_backplane_map`.
 
         Returns:
-            Array containing map of the ring plane distance from the observer in km
-            obscuring each point on the target's surface, calculated using
-            :func:`Body.ring_plane_coordinates`. Points where the target body is
-            unobscured by the ring plane have a value of NaN.
+            :ref:`Read-only array<readonly arrays>` containing map of the ring plane
+            distance from the observer in km obscuring each point on the target's
+            surface, calculated using :func:`Body.ring_plane_coordinates`. Points where
+            the target body is unobscured by the ring plane have a value of NaN.
         """
         return self._get_ring_plane_coordinate_maps(**map_kwargs)[2]
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -949,3 +949,25 @@ class TestFunctions(common_testing.BaseTestCase):
             'zzz.txt',
         ]
         self.assertEqual(planetmapper.base.sort_kernel_paths(input), expected)
+
+    def test_as_readonly_view(self):
+        a = np.array([1, 2, 3])
+        a[0] = 0
+        a_ret = planetmapper.base._as_readonly_view(a)
+        self.assertIsNot(a_ret, a)
+        self.assertEqual(a.flags.writeable, True)
+        self.assertEqual(a_ret.flags.writeable, False)
+        with self.assertRaises(ValueError):
+            a_ret[0] = 10
+        a[0] = 9
+        self.assertEqual(a[0], a_ret[0])
+
+    @planetmapper.base._return_readonly_array
+    def f_readonly(self, a: np.ndarray, b: float) -> np.ndarray:
+        return a + b
+
+    def test_return_readonly_array(self):
+        out = self.f_readonly(np.array([1, 2, 3]), 1)
+        self.assertEqual(out.flags.writeable, False)
+        with self.assertRaises(ValueError):
+            out[0] = 0

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -1520,6 +1520,10 @@ class TestBodyXY(common_testing.BaseTestCase):
                 )
                 self.assertTrue(np.allclose(xx, xx_expected), msg=repr(xx))
                 self.assertTrue(np.allclose(yy, yy_expected), msg=repr(yy))
+                self.assertFalse(lons.flags.writeable)
+                self.assertFalse(lats.flags.writeable)
+                self.assertFalse(xx.flags.writeable)
+                self.assertFalse(yy.flags.writeable)
 
         # Test proj strings
         jupiter = BodyXY(
@@ -1729,6 +1733,22 @@ class TestBodyXY(common_testing.BaseTestCase):
             )
         )
         self.body.set_img_size(15, 10)
+
+    def test_backplane_readonly(self):
+        self.body.set_img_size(4, 3)
+        self.body.set_disc_params(2, 1, 1.5, 45.678)
+        for key, backplane in self.body.backplanes.items():
+            with self.subTest(key, func='img'):
+                out = backplane.get_img()
+                self.assertEqual(out.flags.writeable, False)
+                with self.assertRaises(ValueError):
+                    out[0, 0] = 0
+
+            with self.subTest(key, func='map'):
+                out = backplane.get_map(degree_interval=45)
+                self.assertEqual(out.flags.writeable, False)
+                with self.assertRaises(ValueError):
+                    out[0, 0] = 0
 
     @patch('matplotlib.pyplot.show')
     def test_plot_backplane(self, mock_show: MagicMock):


### PR DESCRIPTION
NumPy arrays returned by a variety of PlanetMapper methods are now read-only (i.e. the [writeable flag is False](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html#numpy-ndarray-flags)). This prevents potential bugs where a cached array can be modified by accident. If a mutable array is needed, then `array.copy()` can be used to create a writeable version of an array:

```python
lon_img = body.get_lon_img().copy()
```

All backplane methods now return read-only arrays, and the arrays returned by `generate_map_coordinates` are also read-only.

Closes #417 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.