### PR TITLE
Fix failing automated tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     Literal,
     ParamSpec,
+    Sequence,
     TypedDict,
     TypeVar,
     cast,
@@ -2514,7 +2515,7 @@ class Body(BodyBase):
 
     def visible_lon_grid_radec(
         self,
-        lons: list[float] | np.ndarray,
+        lons: Sequence[float] | np.ndarray,
         npts: int = 60,
         *,
         lat_limit: float = 90.0,
@@ -2565,7 +2566,7 @@ class Body(BodyBase):
 
     def visible_lat_grid_radec(
         self,
-        lats: list[float] | np.ndarray,
+        lats: Sequence[float] | np.ndarray,
         npts: int = 120,
         *,
         lat_limit: float = 90.0,
@@ -3070,7 +3071,9 @@ class Body(BodyBase):
                     ),
                 )
             lats = [
-                l for l in np.arange(-90, 90, grid_interval) if abs(l) <= grid_lat_limit
+                float(l)
+                for l in np.arange(-90, 90, grid_interval)
+                if abs(l) <= grid_lat_limit
             ]
             for lat, (ra, dec) in zip(
                 lats,

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1580,7 +1580,7 @@ class BodyXY(Body):
                 )
         npts = 720
         for lat in lat_ticks:
-            if lat in {-90, 90}:
+            if float(lat) in {-90.0, 90.0}:
                 continue
             if abs(lat) > grid_lat_limit:
                 continue

--- a/planetmapper/utils.py
+++ b/planetmapper/utils.py
@@ -5,7 +5,7 @@ Various general helpful utilities.
 import os
 import pathlib
 import warnings
-from typing import Literal
+from typing import Literal, Sequence
 
 import matplotlib.ticker
 import numpy as np
@@ -239,7 +239,7 @@ class filter_fits_comment_warning(warnings.catch_warnings):
 
 
 def normalise(
-    values: np.ndarray | list[float],
+    values: np.ndarray | Sequence[float],
     top: float = 1.0,
     bottom: float = 0.0,
     single_value: float | None = None,

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -13,6 +13,9 @@ if [ ! -d "python-type-stubs" ]; then
     git clone https://github.com/microsoft/python-type-stubs python-type-stubs
 fi
 
+echo -e "\nUpdating python-type-stubs (for use with pyright)..."
+cd python-type-stubs && git pull && cd ..
+
 # Allow the docstring check to fail (end line with ";"), all others should cause
 # the script to stop (end lines with "&&"), as the docstring check only really
 # matters when we are releasing a new version, so it's normal for it to fail when


### PR DESCRIPTION
Fixes tests that were failing after updates to pylance and pylint:
- Change type hints to work better with `np.floating`/`float` values
- Temporarily disable Python 3.13 checks with Pylint due to a bug in Pylint (see #433)

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.