### PR TITLE
Minimise spherical distortion of the wireframes of very large angular diameter targets in the GUI

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -108,11 +108,11 @@ This will create a copy of the array that you can safely modify, without affecti
 
 Wireframe plots appear warped or distorted
 ==========================================
-This is most likely to occur when using :func:`planetmapper.Body.plot_wireframe_radec` for a target located near the celestial pole (i.e. the target's declination is near 90° or -90°). The `plot can be distorted <https://github.com/ortk95/planetmapper/issues/323>`_ because spherical coordinates (like RA/Dec) are fundamentally impossible to represent perfectly in a 2D cartesian plot, with the distortion increasing at high declinations near the coordinate singularity at the celestial poles.
+This is most likely to occur when using :func:`planetmapper.Body.plot_wireframe_radec` for a target located near the celestial pole (i.e. the target's declination is near 90° or -90°) or has a very large angular diameter (e.g. \>30°). The `plot can be distorted <https://github.com/ortk95/planetmapper/issues/323>`_ because spherical coordinates (like RA/Dec) are fundamentally impossible to represent perfectly in a 2D cartesian plot, with the distortion increasing at high declinations near the coordinate singularity at the celestial poles.
 
 To fix this, you can use the :func:`planetmapper.Body.plot_wireframe_angular`, which by default uses a coordinate system centred on the target body, which minimises any distortion. The origin of the `angular` coordinate system can also be customised to be any point in the sky, for example, using `body.plot_wireframe_angular(origin_ra=0, origin_dec=90)` may be useful for plotting observations in the sky around the north celestial pole.
 
-Plots may also appear distorted if using :func:`planetmapper.Body.plot_wireframe_angular` with a a custom origin that is a large distance from the target body.
+Plots may also appear distorted if using :func:`planetmapper.Body.plot_wireframe_angular` with a custom origin that is a large distance from the target body.
 
 
 RA/Dec wireframe plots appear split into two halves

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -3254,9 +3254,9 @@ class Body(BodyBase):
 
             Even though the numerical values will be correct, the plot may appear warped
             or distorted if the target is near the celestial pole (i.e. the target's
-            declination is near 90° or -90°). This is due to the spherical nature of the
-            RA/Dec coordinate system, which is impossible to represent perfectly on a 2D
-            cartesian plot.
+            declination is near 90° or -90°) or has a very large angular diameter (e.g.
+            >30°). This is due to the spherical nature of the RA/Dec coordinate system,
+            which is impossible to represent perfectly on a 2D cartesian plot.
 
             :func:`plot_wireframe_angular` can be used as an alternative to
             :func:`plot_wireframe_radec` to plot the wireframe without distortion from


### PR DESCRIPTION
Changed the GUI wireframe to use the angular coordinate system internally (rather than the radec coordinate system). This minimises any spherical distortion that can warp the wireframe for very large angular diameter targets (e.g. Jupiter being ~40˚ in a Juno PJ).

The internal backplane calculations already use the angular coordinate system, and numerical values are unchanged, so this is a cosmetic change to help with fitting very large targets with the GUI.

Before:
<img width="912" alt="Image" src="https://github.com/user-attachments/assets/fe5e80f6-2e29-4dda-9527-3f828829ccdf" />

After:
<img width="912" alt="Image" src="https://github.com/user-attachments/assets/e70f30e7-6ef4-40f8-8825-89b6e84db45f" />

Closes #456


### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.