### PR TITLE
Pin specific versions of development requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,16 @@ updates:
       interval: "monthly"
     target-branch: "dev"
     groups:
-      pip-requirements:
+      package-requirements:
         applies-to: version-updates
         patterns:
           - "*"
+        exclude-patterns:
+          - "black"
+          - "isort"
+          - "pyright"
+          - "pylint"
+          - "coverage"
+          - "sphinx"
+          - "sphinx_rtd_theme"
+          - "setuptools"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,12 @@ changelog:
       exclude:
         labels:
           - dependencies
+          - logistics
+          - tests
+    - title: Development
+      labels:
+        - logistics
+        - tests
     - title: Dependencies
       labels:
         - dependencies

--- a/.github/workflows/check-docstring-versions.yml
+++ b/.github/workflows/check-docstring-versions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install packaging
+          pip install -r dev_requirements.txt
       - name: Check docstring version directives
         run: |
           python check_docstring_version_directives.py

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pyright setuptools
+          pip install -r requirements.txt -r dev_requirements.txt
       - name: Get type stubs
         run: |
           git clone https://github.com/microsoft/python-type-stubs python-type-stubs
@@ -53,8 +52,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint setuptools
-        pip install -r requirements.txt
+        pip install -r requirements.txt -r dev_requirements.txt
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files 'planetmapper/*.py') setup.py check_release_version.py
@@ -77,8 +75,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements.txt -r dev_requirements.txt
         pip install coveralls coverage[toml]
-        pip install -r requirements.txt
     - name: Run tests
       run: |
         python -m coverage run -m unittest discover -s tests -v

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev_requirements.txt
+          pip install -r dev_requirements.txt
       - name: Run Black
         run: |
           black . --check --diff
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r dev_requirements.txt
+          pip install -r dev_requirements.txt
       - name: Run isort
         run: |
           isort . --check --diff

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,13 +7,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: psf/black@stable
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev_requirements.txt
+      - name: Run Black
+        run: |
+          black . --check --diff
 
   isort:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: isort/isort-action@v1
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r dev_requirements.txt
+      - name: Run isort
+        run: |
+          isort . --check --diff
   
   pyright:
     runs-on: ubuntu-latest

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,10 +1,10 @@
 # Developemnt requirements (e.g. for run_checks.sh)
-black
-isort
-pyright
-pylint
-coverage
-sphinx
-sphinx_rtd_theme
-setuptools
+black==25.1.0
+isort==6.0.1
+pyright==1.1.401
+pylint==3.3.7
+coverage==7.8.2
+sphinx==5.3.0
+sphinx_rtd_theme==1.3.0
+setuptools==78.1.1
 -r docs/requirements.txt

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,6 +7,7 @@ coverage==7.8.2
 sphinx==5.3.0
 sphinx_rtd_theme==1.3.0
 setuptools==78.1.1
+packaging==25.0
 -r docs/requirements.txt
 
 # Copy any changes here to exclude-patterns in dependabot.yml

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -8,3 +8,5 @@ sphinx==5.3.0
 sphinx_rtd_theme==1.3.0
 setuptools==78.1.1
 -r docs/requirements.txt
+
+# Copy any changes here to exclude-patterns in dependabot.yml

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -16,6 +16,10 @@ fi
 echo -e "\nUpdating python-type-stubs (for use with pyright)..."
 cd python-type-stubs && git pull && cd ..
 
+# Check current environment is consistent with the requirements
+echo -e "\nChecking environment is consistent with requirements..."
+pip install -r requirements.txt -r dev_requirements.txt --dry-run | grep "Would install" || echo "All requirements are satisfied."
+
 # Allow the docstring check to fail (end line with ";"), all others should cause
 # the script to stop (end lines with "&&"), as the docstring check only really
 # matters when we are releasing a new version, so it's normal for it to fail when

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -25,8 +25,8 @@ pip install -r requirements.txt -r dev_requirements.txt --dry-run | grep "Would 
 # matters when we are releasing a new version, so it's normal for it to fail when
 # the next version number is currently unknown.
 echo -e "\nChecking documentation version directives..." && python check_docstring_version_directives.py; \
-echo -e "\nRunning black..." && black . --check && \
-echo -e "\nRunning isort..." && isort . --check && \
+echo -e "\nRunning black..." && black . --check --diff && \
+echo -e "\nRunning isort..." && isort . --check --diff && \
 echo -e "\nRunning pyright..." && pyright && \
 echo -e "\nRunning pylint..." && pylint $(git ls-files 'planetmapper/*.py') setup.py check_release_version.py && \
 echo -e "\nRunning tests..." && python -m coverage run -m unittest discover -s tests && python -m coverage report && python -m coverage html && \


### PR DESCRIPTION
`dev_requirements.txt` now includes specific versions of development requirements (e.g. `black` for formatting or `pyright` for static code analysis). This should help ensure a consistent development environment for PlanetMapper and its tests. 

These dev requirements should now also be automatically updated by dependabot, making it clearer when a code change has broken a CI check, or when a dependency update has.

Closes #463 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.