### PR TITLE
Add `__main__.py` to enable running the PlanetMapper CLI with `python -m planetmapper`

### DIFF
--- a/planetmapper/__main__.py
+++ b/planetmapper/__main__.py
@@ -1,0 +1,6 @@
+# Basic file to enable running the CLI with `python -m planetmapper`
+# https://docs.python.org/3/library/__main__.html#main-py-in-python-packages
+
+from . import cli
+
+cli.main()

--- a/planetmapper/cli.py
+++ b/planetmapper/cli.py
@@ -22,6 +22,9 @@ def main(args: list[str] | None = None) -> None:
     """
     Entry point for CLI.
 
+    If args is None, then parse_args() uses sys.argv[1:] to get the command line
+    arguments.
+
     :meta private:
     """
     parsed_args = _get_parser().parse_args(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ import planetmapper
 import planetmapper.cli
 
 
-class TestCommon(common_testing.BaseTestCase):
+class TestCLI(common_testing.BaseTestCase):
     @patch('planetmapper.cli._run_gui')
     def test_main(self, mock_run_gui: MagicMock):
         planetmapper.cli.main([])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,12 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import common_testing
+
+
+class TestMain(common_testing.BaseTestCase):
+    @patch('planetmapper.cli.main')
+    def test_main(self, mock_cli_main: MagicMock):
+        import planetmapper.__main__
+
+        mock_cli_main.assert_called_once()


### PR DESCRIPTION
PlanetMapper can now be run with `python -m planetmapper` (in addition to the pre-existing bare `planetmapper`). 

https://docs.python.org/3/library/__main__.html#main-py-in-python-packages

Closes #450

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.