### PR TITLE
Ensure some parameters are always floats

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -573,7 +573,7 @@ class Body(BodyBase):
         # Do this after finding the subpoint so that a SpiceBODIESNOTDISTINCT error
         # will have already been raised if the target == the observer (which would mean
         # target_distance=0, causing a numpy warning).
-        self.target_diameter_arcsec = (
+        self.target_diameter_arcsec = float(
             2.0 * 60.0 * 60.0 * np.rad2deg(np.arcsin(self.r_eq / self.target_distance))
         )
         self.km_per_arcsec = (2.0 * self.r_eq) / self.target_diameter_arcsec
@@ -608,8 +608,8 @@ class Body(BodyBase):
         # This is split out into a separate method so that it can be called from
         # __init__ and from _AdjustedSurfaceAltitude
         self.radii = radii
-        self.r_eq = self.radii[0]
-        self.r_polar = self.radii[2]
+        self.r_eq = float(self.radii[0])
+        self.r_polar = float(self.radii[2])
         self.flattening = (self.r_eq - self.r_polar) / self.r_eq
 
     def __repr__(self) -> str:

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -819,7 +819,7 @@ class BodyXY(Body):
         Returns:
             Rotation of the target body.
         """
-        return np.rad2deg(self._get_rotation_radians())
+        return float(np.rad2deg(self._get_rotation_radians()))
 
     def set_plate_scale_arcsec(self, arcsec_per_px: float) -> None:
         """

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -155,6 +155,12 @@ class TestBody(common_testing.BaseTestCase):
         self.assertTrue(np.isnan(sun.subsol_lon))
         self.assertTrue(np.isnan(sun.subsol_lat))
 
+        # Check types are actually floats and not e.g. np.float64
+        self.assertIs(type(self.body.flattening), float)
+        self.assertIs(type(self.body.km_per_arcsec), float)
+        self.assertIs(type(self.body.r_eq), float)
+        self.assertIs(type(self.body.r_polar), float)
+
     def test_repr(self):
         self.assertEqual(
             repr(self.body),

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -448,6 +448,10 @@ class TestBodyXY(common_testing.BaseTestCase):
                 with self.subTest(setter=setter, v=v):
                     setter(v)
                     self.assertAlmostEqual(getter(), v)
+                    # Explicitly check for is float here as we want to ensure
+                    # subclasses (like np.float64) are not used. See #467.
+                    self.assertIs(type(getter()), float)
+
         for setter, getter in functions:
             with self.subTest(setter=setter):
                 with self.assertRaises(ValueError):


### PR DESCRIPTION
For consistency, explicitly convert some values (e.g. the value from `get_rotation`) to `float`. This ensures that they aren't some subclass like `np.float64`. This is mainly a cosmetic change, so that e.g. the output of `get_disc_params` returns a consistent tuple of types.

Closes #467

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.