### PR TITLE
Improve documentation of coordinate systems

### DIFF
--- a/planetmapper/__init__.py
+++ b/planetmapper/__init__.py
@@ -3,12 +3,18 @@ PlanetMapper: A Python package for visualising, navigating and mapping Solar Sys
 observations.
 
 ..
-    See https://planetmapper.readthedocs.io for full documentation.
+    See https://planetmapper.readthedocs.io for full documentation & installation
+    instructions.
 
 The core logic of this code is based on conversion between different coordinate systems
 of interest. The `xy` and `radec` coordinate systems define positions from the point of
 view of the observer while the `lonlat` coordinate system defines locations on the
 surface of the target body:
+
+----
+
+.. _pixel coordinate:
+.. _image pixel coordinates:
 
 `xy`: image pixel coordinates. These coordinates count the number of pixels in an
 observed image with the bottom left pixel defined as `(0, 0)`, and the `x` and `y`
@@ -16,29 +22,52 @@ coordinates defined as normal. Integer coordinates represent the middle of the
 corresponding pixel, so `(0, 3)` covers `x` values from -0.5 to 0.5 and `y` values from
 2.5 to 3.5.
 
-`radec`: observer frame RA/Dec sky coordinates. These are the right ascension and
+----
+
+.. _RA/Dec celestial coordinates:
+
+`radec`: observer frame RA/Dec celestial coordinates. These are the right ascension and
 declination which define the position in the sky of a point from the point of view of
 the observer. These coordinates are expressed in degrees. See
 `Wikipedia <https://en.wikipedia.org/wiki/Equatorial_coordinate_system>`__ for more
 details.
 
+----
+
+.. _longitude/latitude coordinates:
+
 `lonlat`: planetographic coordinates on target body. These are the planetographic
-longitude and latitude coordinates of a point on the surface of the target body. These
-coordinates are expressed in degrees. See
+longitude and latitude coordinates of a point on the surface of the target body,
+expressed in degrees. See
 `Wikipedia <https://en.wikipedia.org/wiki/Planetary_coordinate_system>`__ and
 `the SPICE documentation <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/recpgr_c.html#Particulars>`__
 for more details. The surface altitude can also be customised with the `alt` parameter,
 for example, `body.lonlat2radec(12, 34, alt=1000)` will calculate the RA/Dec coordinates
-of the point at planetographic coordinates (12, 34) and with an altitude of 1000 km. If
-planetocentric coordinates are desired, then functions
+of the point at planetographic coordinates (12, 34) and with an altitude of 1000 km.
+
+If planetocentric longitude/latitude coordinates are desired, then functions
 :func:`Body.graphic2centric_lonlat` and :func:`Body.centric2graphic_lonlat` can be used
-to convert between planetographic and planetocentric coordinates.
+to convert between planetographic and planetocentric coordinates: ::
+
+    # Use planetocentric coordinates as inputs to PlanetMapper methods
+    radec = body.lonlat2radec(*body.centric2graphic_lonlat(12, 34), alt=1000)
+
+    # Convert PlanetMapper lonlat outputs to planetocentric coordinates
+    lonlat_centric = body.graphic2centric_lonlat(*body.radec2lonlat(12, 34))
+
+----
+
+.. _distance coordinates:
 
 `km`: defines the distance in the image plane from the centre of the target body in km
 with the target's north pole pointing up. This coordinate system is similar to the
 `radec` and `xy` coordinate systems, but has the image zoomed so that the planet's
 radius is fixed and rotated so that the north pole points up. It can therefore be useful
 for comparing observations of the same target taken at different times.
+
+----
+
+.. _relative angular coordinates:
 
 `angular`: relative angular coordinates in arcseconds. By default, the angular
 coordinates are centred on the target body, with the same rotation as the `radec`
@@ -50,6 +79,8 @@ customising the `angular` coordinates. Similarly to the `km` coordinate system, 
 can be useful for comparing observations of the same target taken at different times. It
 also can be used to minimise the distortion present when plotting `radec` coordinates
 for targets located near the celestial pole.
+
+----
 
 =====================================================   =====
 Dimension                                               Unit

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -427,13 +427,13 @@ class Body(BodyBase):
         self.subpoint_distance: float
         """Distance from the observer to the sub-observer point on the target."""
         self.subpoint_lon: float
-        """Longitude of the sub-observer point on the target."""
+        """Planetographic longitude of the sub-observer point on the target."""
         self.subpoint_lat: float
-        """Latitude of the sub-observer point on the target."""
+        """Planetographic latitude of the sub-observer point on the target."""
         self.subsol_lon: float
-        """Longitude of the sub-solar point on the target."""
+        """Planetographic longitude of the sub-solar point on the target."""
         self.subsol_lat: float
-        """Latitude of the sub-solar point on the target."""
+        """Planetographic latitude of the sub-solar point on the target."""
         self.named_ring_data: dict[str, list[float]]
         """
         Dictionary of ring radii for the target from :func:`data_loader.get_ring_radii`.
@@ -477,17 +477,18 @@ class Body(BodyBase):
         """
         self.coordinates_of_interest_lonlat: list[tuple[float, float]]
         """
-        List of `(lon, lat)` coordinates of interest on the surface of the target body
-        to mark when plotting (points which are not visible will not be plotted). To add
-        a new point of interest, simply append a coordinate pair to this list: ::
+        List of `(lon, lat)` planetographic `longitude/latitude coordinates`_ of
+        interest on the surface of the target body to mark when plotting (points which
+        are not visible will not be plotted). To add a new point of interest, simply
+        append a coordinate pair to this list: ::
 
             body.coordinates_of_interest_lonlat.append((0, -22))
         """
         self.coordinates_of_interest_radec: list[tuple[float, float]]
         """
-        List of `(ra, dec)` sky coordinates of interest to mark when plotting (e.g. 
-        background stars). To add new point of interest, simply append a coordinate pair
-        to this list: ::
+        List of `(ra, dec)` `RA/Dec celestial coordinates`_ of interest to mark when
+        plotting (e.g. background stars). To add new point of interest, simply append a
+        coordinate pair to this list: ::
 
             body.coordinates_of_interest_radec.append((200, -45))
         """
@@ -1068,8 +1069,8 @@ class Body(BodyBase):
         not_visible_nan: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert longitude/latitude coordinates on the target body to RA/Dec sky
-        coordinates for the observer.
+        Convert `longitude/latitude coordinates`_ on the target body to `RA/Dec
+        celestial coordinates`_ for the observer.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1078,8 +1079,8 @@ class Body(BodyBase):
         NumPy arrays will be returned.
 
         Args:
-            lon: Longitude of point(s) on target body.
-            lat: Latitude of point(s) on target body.
+            lon: Planetographic longitude of point(s) on target body.
+            lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
             not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
                 the point is not visible to the observer (e.g. it is on the far side of
@@ -1109,8 +1110,8 @@ class Body(BodyBase):
         alt: float = 0.0,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert RA/Dec sky coordinates for the observer to longitude/latitude
-        coordinates on the target body.
+        Convert `RA/Dec celestial coordinates`_ for the observer to `longitude/latitude
+        coordinates`_ on the target body.
 
         The provided RA/Dec will not necessarily correspond to any longitude/latitude
         coordinates, as they could be 'missing' the target and instead be observing the
@@ -1133,10 +1134,10 @@ class Body(BodyBase):
                 body in km.
 
         Returns:
-            `(lon, lat)` tuple containing the longitude/latitude coordinates on the
-            target body. If the provided RA/Dec coordinates are missing the target body
-            and `not_found_nan` is True, then the `lon` and `lat` values will both be
-            NaN.
+            `(lon, lat)` tuple containing the planetographic longitude/latitude
+            coordinates on the target body. If the provided RA/Dec coordinates are
+            missing the target body and `not_found_nan` is True, then the `lon` and
+            `lat` values will both be NaN.
 
         Raises:
             NotFoundError: If the provided RA/Dec coordinates are missing the target
@@ -1157,12 +1158,13 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0, not_visible_nan: bool = False
     ) -> np.ndarray:
         """
-        Convert longitude/latitude coordinates on the target body to rectangular vector
-        centred in the target frame (e.g. for use as an input to a SPICE function).
+        Convert `longitude/latitude coordinates`_ on the target body to rectangular
+        vector centred in the target frame (e.g. for use as an input to a SPICE
+        function).
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
             not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
                 the point is not visible to the observer (e.g. it is on the far side of
@@ -1183,8 +1185,8 @@ class Body(BodyBase):
         self, targvec: np.ndarray, *, alt: float = 0.0
     ) -> tuple[float, float]:
         """
-        Convert rectangular vector centred in the target frame to longitude/latitude
-        coordinates on the target body (e.g. to convert the output from a SPICE
+        Convert rectangular vector centred in the target frame to `longitude/latitude
+        coordinates`_ on the target body (e.g. to convert the output from a SPICE
         function).
 
         Args:
@@ -1193,8 +1195,8 @@ class Body(BodyBase):
                 body in km.
 
         Returns:
-            `(lon, lat)` tuple containing the longitude and latitude corresponding to
-            the input vector.
+            `(lon, lat)` tuple containing the planetographic longitude/latitude
+            corresponding to the input vector.
         """
         with _AdjustedSurfaceAltitude(self, alt):
             return self._radian_pair2degrees(*self._targvec2lonlat_radians(targvec))
@@ -1299,7 +1301,7 @@ class Body(BodyBase):
         coordinate_rotation: float = 0.0,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert RA/Dec sky coordinates for the observer to relative angular coordinates.
+        Convert `RA/Dec celestial coordinates`_ for the observer to relative angular coordinates.
 
         The origin and rotation of the relative angular coordinates can be customised
         using the `origin_ra`, `origin_dec` and `coordinate_rotation` arguments. If
@@ -1361,7 +1363,8 @@ class Body(BodyBase):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert relative angular coordinates to RA/Dec sky coordinates for the observer.
+        Convert `relative angular coordinates`_ to `RA/Dec celestial coordinates` for
+        the observer.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1403,8 +1406,8 @@ class Body(BodyBase):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert relative angular coordinates to longitude/latitude coordinates on the
-        target body.
+        Convert `relative angular coordinates`_ to `longitude/latitude coordinates`_ on
+        the target body.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1424,9 +1427,10 @@ class Body(BodyBase):
                 :func:`radec2angular` for details.
 
         Returns:
-            `(lon, lat)` tuple containing the longitude and latitude of the point(s). If
-            the provided angular coordinates are missing the target body and
-            `not_found_nan` is True, then the `lon` and `lat` values will both be NaN.
+            `(lon, lat)` tuple containing the planetographic longitude/latitude of the
+            point(s). If the provided angular coordinates are missing the target body
+            and `not_found_nan` is True, then the `lon` and `lat` values will both be
+            NaN.
 
         Raises:
             NotFoundError: If the provided angular coordinates are missing the target
@@ -1466,8 +1470,8 @@ class Body(BodyBase):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert longitude/latitude coordinates on the target body to relative angular
-        coordinates.
+        Convert `longitude/latitude coordinates`_ on the target body to `relative
+        angular coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1476,8 +1480,8 @@ class Body(BodyBase):
         NumPy arrays will be returned.
 
         Args:
-            lon: Longitude of point(s) on target body.
-            lat: Latitude of point(s) on target body.
+            lon: Planetographic longitude of point(s) on target body.
+            lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
             not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
                 the point is not visible to the observer (e.g. it is on the far side of
@@ -1546,7 +1550,8 @@ class Body(BodyBase):
         self, km_x: FloatOrArray, km_y: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert distance in target plane to RA/Dec sky coordinates for the observer.
+        Convert `distance coordinates`_ in target plane to `RA/Dec celestial
+        coordinates`_ for the observer.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1570,8 +1575,8 @@ class Body(BodyBase):
         self, ra: FloatOrArray, dec: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert RA/Dec sky coordinates for the observer to distances in the target
-        plane.
+        Convert `RA/Dec celestial coordinates`_ for the observer to `distance
+        coordinates`_ in the target plane.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1601,8 +1606,8 @@ class Body(BodyBase):
         alt: float = 0.0,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert distance in target plane to longitude/latitude coordinates on the target
-        body.
+        Convert `distance coordinates`_ in target plane to `longitude/latitude
+        coordinates`_ on the target body.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1619,10 +1624,10 @@ class Body(BodyBase):
                 body in km.
 
         Returns:
-            `(lon, lat)` tuple containing the longitude and latitude of the point(s). If
-            the provided km coordinates are missing the target body, then the `lon` and
-            `lat` values will both be NaN if `not_found_nan` is True, otherwise a
-            NotFoundError will be raised.
+            `(lon, lat)` tuple containing planetographic longitude/latitude of the
+            point(s). If the provided km coordinates are missing the target body, then
+            the `lon` and `lat` values will both be NaN if `not_found_nan` is True,
+            otherwise a NotFoundError will be raised.
 
         Raises:
             NotFoundError: If the provided km coordinates are missing the target body
@@ -1648,8 +1653,8 @@ class Body(BodyBase):
         not_visible_nan: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert longitude/latitude coordinates on the target body to distances in the
-        target plane.
+        Convert `longitude/latitude coordinates`_ on the target body to `distance
+        coordinates`_ in the target plane.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1658,8 +1663,8 @@ class Body(BodyBase):
         NumPy arrays will be returned.
 
         Args:
-            lon: Longitude of point(s) on the target body.
-            lat: Latitude of point(s) on the target body.
+            lon: Planetographic longitude of point(s) on target body.
+            lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
             not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
                 the point is not visible to the observer (e.g. it is on the far side of
@@ -1688,7 +1693,8 @@ class Body(BodyBase):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert distance in target plane to relative angular coordinates.
+        Convert `distance coordinates`_ in target plane to `relative angular
+        coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1726,7 +1732,8 @@ class Body(BodyBase):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert relative angular coordinates to distances in the target plane.
+        Convert `relative angular coordinates`_ to `distance coordinates`_ in the target
+        plane.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -1815,7 +1822,7 @@ class Body(BodyBase):
         self, *, alt: float = 0.0, **kwargs
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Calculate the RA/Dec coordinates of the target body's limb.
+        Calculate the `RA/Dec celestial coordinates`_ of the target body's limb.
 
         Args:
             npts: Number of points in the generated limb.
@@ -1831,7 +1838,7 @@ class Body(BodyBase):
         self, *, alt: float = 0.0, **kwargs
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
-        Calculate RA/Dec coordinates of the dayside and nightside parts of the target
+        Calculate `RA/Dec celestial coordinates`_ of the dayside and nightside parts of the target
         body's limb.
 
         Output arrays are like the outputs of :func:`limb_radec`, but the dayside
@@ -1862,14 +1869,14 @@ class Body(BodyBase):
 
     def limb_lonlat(self, alt: float = 0.0, **kwargs) -> tuple[np.ndarray, np.ndarray]:
         """
-        Calculate the Lon/Lat coordinates of the target body's limb.
+        Calculate the `longitude/latitude coordinates`_ of the target body's limb.
 
         Args:
             npts: Number of points in the generated limb.
             alt: Altitude of the limb above the surface of the target body, in km.
 
         Returns:
-            `(lon, lat)` tuple of coordinate arrays.
+            `(lon, lat)` tuple of planetographic longitude/latitude arrays.
         """
         with _AdjustedSurfaceAltitude(self, alt):
             lons, lats = zip(
@@ -1884,8 +1891,8 @@ class Body(BodyBase):
         self, ra: float, dec: float, *, alt: float = 0.0
     ) -> tuple[float, float, float]:
         """
-        Calculate the coordinates relative to the target body's limb for a point in the
-        sky.
+        Calculate the coordinates relative to the target body's limb for given
+        `RA/Dec celestial coordinates`_ in the sky of the observer.
 
         The coordinates are calculated for the point on the ray (as defined by RA/Dec)
         which is closest to the target body's limb.
@@ -1986,11 +1993,12 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> bool:
         """
-        Test if longitude/latitude coordinate on (or above) the target body is visible.
+        Test if `longitude/latitude coordinates`_ on (or above) the target body is
+        visible.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2119,12 +2127,12 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> tuple[float, float, float]:
         """
-        Calculate the illumination angles of a longitude/latitude coordinate on the
+        Calculate the illumination angles of `longitude/latitude coordinates`_ on the
         target body.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2154,12 +2162,12 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> float:
         """
-        Calculate the azimuth angle of a longitude/latitude coordinate on the target
+        Calculate the azimuth angle of `longitude/latitude coordinates`_ on the target
         body.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2200,7 +2208,7 @@ class Body(BodyBase):
             for more details.
 
         Args:
-            lon: Longitude of point on target body.
+            lon: Planetographic longitude of point on target body.
 
         Returns:
             Numerical local solar time in 'local hours'.
@@ -2217,7 +2225,7 @@ class Body(BodyBase):
         See :func:`local_solar_time_from_lon` for more details.
 
         Args:
-            lon: Longitude of point on target body.
+            lon: Planetographic longitude of point on target body.
 
         Returns:
             String representation of local solar time.
@@ -2236,9 +2244,9 @@ class Body(BodyBase):
         corloc: str = 'ELLIPSOID TERMINATOR',
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Calculate the RA/Dec coordinates of the terminator (line between day and night)
-        on the target body. By default, only the visible part of the terminator is
-        returned (this can be changed with `only_visible`).
+        Calculate the `RA/Dec celestial coordinates`_ of the terminator (line between
+        day and night) on the target body. By default, only the visible part of the
+        terminator is returned (this can be changed with `only_visible`).
 
         Args:
             npts: Number of points in generated terminator.
@@ -2273,8 +2281,8 @@ class Body(BodyBase):
         corloc: str = 'ELLIPSOID TERMINATOR',
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Calculate the Lon/Lat coordinates of the terminator (line between day and night)
-        on the target body.
+        Calculate the `longitude/latitude coordinates`_ of the terminator (line between
+        day and night) on the target body.
 
         Args:
             npts: Number of points in generated terminator.
@@ -2285,7 +2293,7 @@ class Body(BodyBase):
             method, corloc: Passed to SPICE function.
 
         Returns:
-            `(lon, lat)` tuple of Lon/Lat coordinate arrays.
+            `(lon, lat)` tuple of planetographic longitude/latitude coordinate arrays.
         """
         targvecs = self._terminator_targvec(
             npts=npts,
@@ -2352,12 +2360,12 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> bool:
         """
-        Test if longitude/latitude coordinate on the surface of the target body is
+        Test if `longitude/latitude coordinates`_ on the surface of the target body is
         illuminated.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2453,7 +2461,7 @@ class Body(BodyBase):
         self, radius: float, npts: int = 360, only_visible: bool = True
     ) -> tuple[np.ndarray, np.ndarray]:
         """
-        Calculate RA/Dec coordinates of a ring around the target body.
+        Calculate `RA/Dec celestial coordinates`_ of a ring around the target body.
 
         The ring is assumed to be directly above the planet's equator and has a constant
         `radius` for all longitudes. Use :attr:`ring_radii` to set the rings
@@ -2508,7 +2516,8 @@ class Body(BodyBase):
 
         Returns:
             List of `(ra, dec)` tuples, each of which corresponds to a gridline. `ra`
-            and `dec` are arrays of RA/Dec coordinate values for that gridline.
+            and `dec` are arrays of `RA/Dec celestial coordinates`_ values for that
+            gridline.
         """
 
         lon_radec = self.visible_lon_grid_radec(np.arange(0, 360, interval), **kwargs)
@@ -2525,7 +2534,8 @@ class Body(BodyBase):
         planetocentric: bool = False,
     ) -> list[tuple[np.ndarray, np.ndarray]]:
         """
-        Calculates the RA/Dec coordinates for visible lines of constant longitude.
+        Calculates the `RA/Dec celestial coordinates`_ for visible lines of constant
+        longitude.
 
         For each longitude in `lons`, a `(ra, dec)` tuple is calculated which contains
         arrays of RA and Dec coordinates. Coordinates which correspond to points which
@@ -2548,7 +2558,8 @@ class Body(BodyBase):
 
         Returns:
             List of `(ra, dec)` tuples, corresponding to the list of input `lons`. `ra`
-            and `dec` are arrays of RA/Dec coordinate values for that gridline.
+            and `dec` are arrays of `RA/Dec celestial coordinates`_ values for that
+            gridline.
         """
         lats = np.linspace(-lat_limit, lat_limit, npts)
         out: list[tuple[np.ndarray, np.ndarray]] = []
@@ -2594,7 +2605,8 @@ class Body(BodyBase):
 
         Returns:
             List of `(ra, dec)` tuples, corresponding to the list of input `lats`. `ra`
-            and `dec` are arrays of RA/Dec coordinate values for that gridline.
+            and `dec` are arrays of `RA/Dec celestial coordinates`_ values for that
+            gridline.
         """
         lons = np.linspace(0, 360, npts)
         out: list[tuple[np.ndarray, np.ndarray]] = []
@@ -2647,13 +2659,13 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> float:
         """
-        Calculate radial (i.e. line-of-sight) velocity of a point on the target's
-        surface relative to the observer. This can be used to calculate the doppler
-        shift.
+        Calculate radial (i.e. line-of-sight) velocity of a point (`longitude/latitude
+        coordinates`_) on the target's surface relative to the observer. This can be
+        used to calculate the doppler shift.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2667,11 +2679,12 @@ class Body(BodyBase):
         self, lon: float, lat: float, *, alt: float = 0.0
     ) -> float:
         """
-        Calculate distance from observer to a point on the target's surface.
+        Calculate distance from observer to a point (`longitude/latitude coordinates`_)
+        on the target's surface.
 
         Args:
-            lon: Longitude of point on target body.
-            lat: Latitude of point on target body.
+            lon: Planetographic longitude of point on target body.
+            lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
@@ -2697,7 +2710,8 @@ class Body(BodyBase):
         self, lon: FloatOrArray, lat: FloatOrArray, *, alt: float = 0.0
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert planetographic longitude/latitude to planetocentric.
+        Convert planetographic `longitude/latitude coordinates`_ to planetocentric
+        longitude/latitude.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -2726,7 +2740,8 @@ class Body(BodyBase):
         self, lon_centric: FloatOrArray, lat_centric: FloatOrArray, *, alt: float = 0.0
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert planetocentric longitude/latitude to planetographic.
+        Convert planetocentric longitude/latitude to planetographic `longitude/latitude
+        coordinates`_ .
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -2740,7 +2755,7 @@ class Body(BodyBase):
             alt: Altitude of point above the surface of the target body in km.
 
         Returns:
-            `(lon, lat)` tuple of planetographic coordinates.
+            `(lon, lat)` tuple of planetographic longitude/latitude.
         """
         return self._maybe_transform_as_arrays(
             self._centric2graphic_lonlat, lon_centric, lat_centric, alt=alt
@@ -3174,8 +3189,8 @@ class Body(BodyBase):
         **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
-        Plot basic wireframe representation of the observation using RA/Dec sky
-        coordinates.
+        Plot basic wireframe representation of the observation using `RA/Dec celestial
+        coordinates`_.
 
         See also :func:`plot_wireframe_km`, :func:`plot_wireframe_angular` and
         :func:`BodyXY.plot_wireframe_xy` to plot the wireframe in other coordinate
@@ -3388,8 +3403,9 @@ class Body(BodyBase):
         **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
-        Plot basic wireframe representation of the observation on a target centred
-        frame. See :func:`plot_wireframe_radec` for details of accepted arguments.
+        Plot basic wireframe representation of the observation on a target centred frame
+        (`distance coordinates`_). See :func:`plot_wireframe_radec` for details of
+        accepted arguments.
 
         Returns:
             The axis containing the plotted wireframe.
@@ -3428,8 +3444,8 @@ class Body(BodyBase):
         **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
-        Plot basic wireframe representation of the observation on a relative angular
-        coordinate frame. See :func:`plot_wireframe_radec` for details of accepted
+        Plot basic wireframe representation of the observation on a `relative angular
+        coordinates`_ frame. See :func:`plot_wireframe_radec` for details of accepted
         arguments.
 
         The `origin_ra`, `origin_dec` and `coordinate_rotation` arguments can be used to

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -114,9 +114,9 @@ class BodyXY(Body):
     Class representing an astronomical body imaged at a specific time.
 
     This is a subclass of :class:`Body` with additional methods to interact with the
-    image pixel coordinate frame `xy`. This class assumes the tangent plane
-    approximation is valid for the conversion between pixel coordinates `xy` and RA/Dec
-    sky coordinates `radec`.
+    `image pixel coordinates`_ frame `xy`. This class assumes the tangent plane
+    approximation is valid for the conversion between pixel coordinates `xy` and `RA/Dec
+    celestial coordinates`_ `radec`.
 
     The `xy` ↔ `radec` conversion is performed by setting the pixel coordinates of the
     centre of the planet's disc `(x0, y0)`, the (equatorial) pixel radius of the disc
@@ -385,7 +385,7 @@ class BodyXY(Body):
         self, x: FloatOrArray, y: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert image pixel coordinates to RA/Dec sky coordinates.
+        Convert `image pixel coordinates`_ to `RA/Dec celestial coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -409,7 +409,7 @@ class BodyXY(Body):
         self, ra: FloatOrArray, dec: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert RA/Dec sky coordinates to image pixel coordinates.
+        Convert `RA/Dec celestial coordinates`_ to `image pixel coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -433,8 +433,8 @@ class BodyXY(Body):
         self, x: FloatOrArray, y: FloatOrArray, *, not_found_nan=True, alt: float = 0.0
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert image pixel coordinates to longitude/latitude coordinates on the target
-        body.
+        Convert `image pixel coordinates`_ to `longitude/latitude coordinates`_ on the
+        target body.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -451,9 +451,10 @@ class BodyXY(Body):
                 body in km.
 
         Returns:
-            `(lon, lat)` tuple containing the longitude and latitude of the point(s). If
-            the provided pixel coordinates are missing the target body, and
-            `not_found_nan` is `True`, then the `lon` and `lat` values will both be NaN.
+            `(lon, lat)` tuple containing the planetographic longitude/latitude of
+            the point(s). If the provided pixel coordinates are missing the target body,
+            and `not_found_nan` is `True`, then the `lon` and `lat` values will both be
+            NaN.
 
         Raises:
             NotFoundError: if the input `x` and `y` coordinates are missing the target
@@ -477,7 +478,8 @@ class BodyXY(Body):
         not_visible_nan: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert longitude/latitude on the target body to image pixel coordinates.
+        Convert `longitude/latitude coordinates`_ on the target body to `image pixel
+        coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -486,8 +488,8 @@ class BodyXY(Body):
         NumPy arrays will be returned.
 
         Args:
-            lon: Longitude of point(s) on target body.
-            lat: Latitude of point(s) on target body.
+            lon: Planetographic longitude of point(s) on target body.
+            lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
             not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
                 the point is not visible to the observer (e.g. it is on the far side of
@@ -512,7 +514,8 @@ class BodyXY(Body):
         self, x: FloatOrArray, y: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert image pixel coordinates to distances in the target plane.
+        Convert `image pixel coordinates`_ to `distance coordinates`_ in the target
+        plane.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -537,7 +540,8 @@ class BodyXY(Body):
         self, km_x: FloatOrArray, km_y: FloatOrArray
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert distances in the target plane to image pixel coordinates.
+        Convert `distance coordinates`_ in the target plane to `image pixel
+        coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -564,7 +568,7 @@ class BodyXY(Body):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert image pixel coordinates to relative angular coordinates.
+        Convert `image pixel coordinates`_ to `relative angular coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -597,7 +601,7 @@ class BodyXY(Body):
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
-        Convert relative angular coordinates to image pixel coordinates.
+        Convert `relative angular coordinates`_ to `image pixel coordinates`_.
 
         The input coordinates can either be floats or NumPy arrays of values. If both
         input coordinates are floats, the output will be a tuple of floats. If either of
@@ -730,7 +734,7 @@ class BodyXY(Body):
     def set_x0(self, x0: float) -> None:
         """
         Args:
-            x0: New x pixel coordinate of the centre of the target body.
+            x0: New x `pixel coordinate`_ of the centre of the target body.
 
         Raises:
             ValueError: if `x0` is not finite.
@@ -743,14 +747,14 @@ class BodyXY(Body):
     def get_x0(self) -> float:
         """
         Returns:
-            x pixel coordinate of the centre of the target body.
+            x `pixel coordinate`_ of the centre of the target body.
         """
         return self._x0
 
     def set_y0(self, y0: float) -> None:
         """
         Args:
-            y0: New y pixel coordinate of the centre of the target body.
+            y0: New y `pixel coordinate`_ of the centre of the target body.
 
         Raises:
             ValueError: if `y0` is not finite.
@@ -763,7 +767,7 @@ class BodyXY(Body):
     def get_y0(self) -> float:
         """
         Returns:
-            y pixel coordinate of the centre of the target body.
+            y `pixel coordinate`_ of the centre of the target body.
         """
         return self._y0
 
@@ -802,7 +806,7 @@ class BodyXY(Body):
 
         This rotation defines the angle between the upwards (positive `dec`) direction
         in the RA/Dec sky coordinates and the upwards (positive `y`) direction in the
-        image pixel coordinates.
+        `image pixel coordinates`_.
 
         Args:
             rotation: New rotation of the target body.
@@ -993,14 +997,14 @@ class BodyXY(Body):
 
         Returns:
             `(x_min, x_max), (y_min, y_max)` tuple containing the minimum and maximum
-            pixel coordinates of the pixels in the image.
+            `image pixel coordinates`_ of the pixels in the image.
         """
         return self._get_img_limits(lambda x, y: (x, y))
 
     # Illumination functions etc.
     def limb_xy(self, **kwargs) -> tuple[np.ndarray, np.ndarray]:
         """
-        Pixel coordinate version of :func:`Body.limb_radec`.
+        `Image pixel coordinates`_ version of :func:`Body.limb_radec`.
 
         Args:
             **kwargs: Passed to :func:`Body.limb_radec`.
@@ -1014,7 +1018,7 @@ class BodyXY(Body):
         self, **kwargs
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
-        Pixel coordinate version of :func:`Body.limb_radec_by_illumination`.
+        `Image pixel coordinates`_ version of :func:`Body.limb_radec_by_illumination`.
 
         Args:
             **kwargs: Passed to :func:`Body.limb_radec_by_illumination`.
@@ -1031,7 +1035,7 @@ class BodyXY(Body):
 
     def terminator_xy(self, **kwargs) -> tuple[np.ndarray, np.ndarray]:
         """
-        Pixel coordinate version of :func:`Body.terminator_radec`.
+        `Image pixel coordinates`_ version of :func:`Body.terminator_radec`.
 
         Args:
             **kwargs: Passed to :func:`Body.terminator_radec`.
@@ -1045,7 +1049,7 @@ class BodyXY(Body):
         self, *args, **kwargs: Unpack[LonLatGridKwargs]
     ) -> list[tuple[np.ndarray, np.ndarray]]:
         """
-        Pixel coordinate version of :func:`Body.visible_lonlat_grid_radec`.
+        `Image pixel coordinates`_ version of :func:`Body.visible_lonlat_grid_radec`.
 
         Args:
             *args: Passed to :func:`Body.visible_lonlat_grid_radec`.
@@ -1061,7 +1065,7 @@ class BodyXY(Body):
 
     def ring_xy(self, radius: float, **kwargs) -> tuple[np.ndarray, np.ndarray]:
         """
-        Pixel coordinate version of :func:`Body.ring_radec`.
+        `Image pixel coordinates`_ version of :func:`Body.ring_radec`.
 
         Args:
             radius: Radius in km of the ring from the centre of the target body.


### PR DESCRIPTION
- Explicitly mention lonlat coords are planetographic in all methods that use/return them.
- Add links to the coordinate system definitions from relevant docstrings.

Closes #472 

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.