### PR TITLE
Ignore PIL "'mode' parameter is deprecated" DeprecationWarning

### DIFF
--- a/tests/common_testing.py
+++ b/tests/common_testing.py
@@ -20,6 +20,16 @@ class BaseTestCase(unittest.TestCase):
         super().setUpClass()
         warnings.filterwarnings('error')
 
+        # Ignore warning from Pillow triggered by some Matplotlib calls on Windows
+        # https://github.com/ortk95/planetmapper/issues/480
+        # TODO remove this filter when matplotlib is updated to fix this
+        warnings.filterwarnings(
+            'ignore',
+            category=DeprecationWarning,
+            module='PIL',
+            message="'mode' parameter is deprecated and will be removed in Pillow 13",
+        )
+
     @classmethod
     def tearDownClass(cls) -> None:
         super().tearDownClass()


### PR DESCRIPTION
The latest version of Pillow 11.3.0 (https://github.com/ortk95/planetmapper/pull/479) emits a DeprecationWarning when calling some Matplotlib functions on Windows, causing some tests to fail. This is a Matplotlib (i.e. not PlanetMapper) issue, so we can safely ignore these warnings when running unit tests for now, until Matplotlib fixes the issue.

Closes #480

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.