### PR TITLE
Add `rotate_north_to_top` method to put the disc's north pole at the top of the image

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -818,6 +818,18 @@ class BodyXY(Body):
             raise ValueError('rotation must be finite')
         self._set_rotation_radians(np.deg2rad(rotation))
 
+    def rotate_north_to_top(self) -> None:
+        """
+        Set the disc rotation so that the north pole of the target body is at the top of
+        the image.
+
+        This is a convenience method, equivalent to calling: ::
+
+            body.set_rotation(-body.north_pole_angle())
+        """
+        self.set_rotation(-self.north_pole_angle())
+        self.set_disc_method('rotate_north_to_top')
+
     def get_rotation(self) -> float:
         """
         Returns:
@@ -892,8 +904,8 @@ class BodyXY(Body):
         :func:`Observation.save`.
 
         `set_disc_method` is called automatically by functions which find the disc, such
-        as :func:`set_x0` and :func:`Observation.centre_disc`, so does not normally need
-        to be manually called by the user.
+        as :func:`rotate_north_to_top` and :func:`Observation.centre_disc`, so does not
+        normally need to be manually called by the user.
 
         Args:
             method: Short string describing the method used to find the disc.

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -292,6 +292,11 @@ class GUI:
                     'Centre disc in image',
                     'Centre the target\'s planetary disc and make it fill ~90% of the observation',
                 ),
+                (
+                    lambda: self.get_observation().rotate_north_to_top(),
+                    'Rotate north to top',
+                    'Rotate the disc so that the north pole of the target is at the top of the image',
+                ),
             ],
             'Use WCS data from FITS header': [
                 (

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -482,6 +482,15 @@ class TestBodyXY(common_testing.BaseTestCase):
         self.assertEqual(self.body.get_disc_params(), (7.0, 4.5, 4.05, 0.0))
         self.assertEqual(self.body.get_disc_method(), 'centre_disc')
 
+    def test_rotate_north_to_top(self):
+        self.body.set_disc_params(0, 0, 1, 0)
+        self.body.rotate_north_to_top()
+        self.assertAlmostEqual(self.body.get_rotation(), 24.15516987997688)
+        self.assertAlmostEqual(
+            self.body.get_rotation(), -self.body.north_pole_angle(), places=3
+        )
+        self.assertEqual(self.body.get_disc_method(), 'rotate_north_to_top')
+
     def test_img_size(self):
         for body in (self.body, self.body_zero_size):
             body.set_disc_params(0, 0, 1, 0)


### PR DESCRIPTION
Add a new `BodyXY.rotate_north_to_top` method, which rotates the target's disc so that north is at the top of the image. This is a convenience method, equivalent to `self.set_rotation(-self.north_pole_angle())`. It also sets the disc method to `'rotate_north_to_top'` for tracking purposes.

Also added an equivalent 'Rotate north to top' button in the GUI:

<img width="912" alt="image" src="https://github.com/user-attachments/assets/958d6248-2458-453c-b600-2aec483ecc88" />


Closes #446

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.