### PR TITLE
Add methods to scale image sizes and add borders around the image

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -921,16 +921,17 @@ class BodyXY(Body):
             raise ValueError('Scaling factor must be greater than zero')
 
         nx, ny = self.get_img_size()
-        new_nx = nx * factor
-        new_ny = ny * factor
-        if not allow_rounding and (not new_nx.is_integer() or not new_ny.is_integer()):
+        nx_f = nx * factor
+        ny_f = ny * factor
+        nx_ceil = math.ceil(nx_f)
+        ny_ceil = math.ceil(ny_f)
+        if not allow_rounding and (nx_ceil != nx_f or ny_ceil != ny_f):
             raise ValueError(
                 f'Image size ({nx}, {ny}) cannot be exactly scaled by {factor} to an '
-                f'integer number of pixels: new size would be ({new_nx}, {new_ny}). '
+                f'integer number of pixels: new size would be ({nx_f}, {ny_f}). '
                 'Use `allow_rounding=True` to allow rounding of the image size.'
             )
-
-        self.set_img_size(math.ceil(new_nx), math.ceil(new_ny))
+        self.set_img_size(nx_ceil, ny_ceil)
         self.set_r0(self.get_r0() * factor)
         # Offset accounts for how the disc position varies slightly with the scaling
         # due to the pixel grid extending from 0.5 to nx-0.5 and ny-0.5.

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -509,11 +509,89 @@ class TestBodyXY(common_testing.BaseTestCase):
         self.assertNotEqual(self.body, self.body_zero_size)
         self.assertFalse(self.body_zero_size._test_if_img_size_valid())
 
+        with self.assertRaises(ValueError):
+            self.body_zero_size.set_img_size(-1, 0)
+        with self.assertRaises(ValueError):
+            self.body_zero_size.set_img_size(0, -1)
+
+        self.body_zero_size.set_img_size(0, 0)
+
     def test_test_if_img_size_valid(self):
         self.assertTrue(self.body._test_if_img_size_valid())
         self.assertFalse(self.body_zero_size._test_if_img_size_valid())
         with self.assertRaises(ValueError):
             self.body_zero_size.get_lon_img()
+
+    def test_scale_img_size(self):
+        def get_body():
+            body = self.body.copy()
+            body.set_img_size(16, 10)
+            body.set_disc_params(3, 4, 5, 6)
+            return body
+
+        body = get_body()
+        body.scale_img_size(1)
+        self.assertEqual(body.get_img_size(), (16, 10))
+        self.assertArraysClose(body.get_disc_params(), (3.0, 4.0, 5.0, 6.0))
+
+        body = get_body()
+        body.scale_img_size(2)
+        self.assertEqual(body.get_img_size(), (32, 20))
+        self.assertArraysClose(body.get_disc_params(), (6.5, 8.5, 10.0, 6.0))
+
+        body = get_body()
+        body.scale_img_size(1.5)
+        self.assertEqual(body.get_img_size(), (24, 15))
+        self.assertArraysClose(body.get_disc_params(), (4.75, 6.25, 7.5, 6.0))
+
+        body = get_body()
+        body.scale_img_size(0.5)
+        self.assertEqual(body.get_img_size(), (8, 5))
+        self.assertArraysClose(body.get_disc_params(), (1.25, 1.75, 2.5, 6.0))
+
+        body = get_body()
+        with self.assertRaises(ValueError):
+            body.scale_img_size(0.25)
+
+        body = get_body()
+        body.scale_img_size(0.25, allow_rounding=True)
+        self.assertEqual(body.get_img_size(), (4, 3))
+        self.assertArraysClose(body.get_disc_params(), (0.375, 0.625, 1.25, 6.0))
+
+        body = get_body()
+        with self.assertRaises(ValueError):
+            body.scale_img_size(-1)
+
+    def test_add_img_border(self):
+        def get_body():
+            body = self.body.copy()
+            body.set_img_size(16, 10)
+            body.set_disc_params(3, 4, 5, 6)
+            return body
+
+        body = get_body()
+        body.add_img_border(0)
+        self.assertEqual(body.get_img_size(), (16, 10))
+        self.assertArraysClose(body.get_disc_params(), (3.0, 4.0, 5.0, 6.0))
+
+        body = get_body()
+        body.add_img_border(1)
+        self.assertEqual(body.get_img_size(), (18, 12))
+        self.assertArraysClose(body.get_disc_params(), (4.0, 5.0, 5.0, 6.0))
+
+        body = get_body()
+        body.add_img_border(42)
+        self.assertEqual(body.get_img_size(), (100, 94))
+        self.assertArraysClose(body.get_disc_params(), (45.0, 46.0, 5.0, 6.0))
+
+        body = get_body()
+        body.add_img_border(-2)
+        self.assertEqual(body.get_img_size(), (12, 6))
+        self.assertArraysClose(body.get_disc_params(), (1.0, 2.0, 5.0, 6.0))
+
+        with self.assertRaises(ValueError):
+            body = get_body()
+            body.add_img_border(-10)
 
     def test_disc_method(self):
         method = ' test method '


### PR DESCRIPTION
Added the methods `BodyXY.scale_img_size` and `BodyXY.add_img_border` to simplify the process of scaling and padding images. `scale_img_size` simplifies the process of increasing/decreasing the pixel resolution of the image, and automatically adjusts the img size, x0, y0 and r0 values. Similarly, `add_img_border` automatically adjusts the img size and the x0 and y0 values.

Example plots before and after scaling with `body.scale_img_size(3)` - the relative wireframe position is unchanged, but the pixel resolution is increased threefold:

![image](https://github.com/user-attachments/assets/2ddabd09-98f6-49be-801b-e7b25c92f77d)
![image](https://github.com/user-attachments/assets/6c50b38b-6e64-40d4-a590-f0c41d695fab)

Example plots before and after adding a 1px border with `body.add_img_border(1)` - the pixel resolution is unchanged, and an extra pixel is added to each side of the image:
![image](https://github.com/user-attachments/assets/e5c95eb8-70d7-4d0e-9f31-69e8940912b2)
![image](https://github.com/user-attachments/assets/ab412f52-9e5a-48d9-9327-9ed0faebd5f3)

The image scaling can be particularly useful to create higher resolution versions of backplanes:
```python
body = planetmapper.BodyXY('jupiter', sz=10)

ax = body.plot_backplane_img('EMISSION')
ax.set_title('Original unscaled backplane')
plt.show()

body_scaled = body.copy()
body_scaled.scale_img_size(10)
ax = body_scaled.plot_backplane_img('EMISSION')
ax.set_title('Scaled higher resolution backplane')
plt.show()
```
![image](https://github.com/user-attachments/assets/c9eccf15-4ae1-4847-b256-1dd636a356a0)
![image](https://github.com/user-attachments/assets/3c16da7c-5a04-421a-8fb7-97db93075147)



Closes #431

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.