### PR TITLE
Improve formatted DMS strings returned by `utils.decimal_degrees_to_dms_str`

### DIFF
--- a/planetmapper/utils.py
+++ b/planetmapper/utils.py
@@ -188,9 +188,9 @@ def decimal_degrees_to_dms(decimal_degrees: float) -> tuple[int, int, float]:
     return int(degrees), int(minutes), seconds
 
 
-def decimal_degrees_to_dms_str(decimal_degrees: float, seconds_fmt: str = '') -> str:
+def decimal_degrees_to_dms_str(decimal_degrees: float, seconds_fmt: str = 'g') -> str:
     """
-    Create nicely formated DMS string from decimal degrees value (e.g. `'12°34′56″'`).
+    Create nicely formatted DMS string from decimal degrees value (e.g. `'12°34′56″'`).
 
     Uses :func:`decimal_degrees_to_dms` to perform the conversion.
 
@@ -198,13 +198,18 @@ def decimal_degrees_to_dms_str(decimal_degrees: float, seconds_fmt: str = '') ->
         decimal_degrees: Decimal degrees.
         seconds_fmt: Optionally specify a format string for the seconds part of the
             returned value. For example, `seconds_fmt='.3f'` will fix three decimal
-            places for the fractional part of the seconds value.
+            places for the fractional part of the seconds value. Note that the integral
+            part of the seconds value will always be zero-padded to two digits, so
+            `seconds_fmt='.3f'` will return seconds as e.g. `01.234`.
 
     Returns:
-        String representting the degress, minutes, seconds of the angle.
+        String representing the degrees, minutes, seconds of the angle.
     """
     d, m, s = decimal_degrees_to_dms(decimal_degrees)
-    return f'{d}°{m}′{s:{seconds_fmt}}″'
+    s_str = f'{s:{seconds_fmt}}'
+    if len(s_str.split('.')[0]) < 2:
+        s_str = '0' + s_str  # Zero pad integer part of seconds to e.g. 01.234
+    return f'{d}°{m:02d}′{s_str}″'
 
 
 class ignore_warnings(warnings.catch_warnings):
@@ -212,9 +217,9 @@ class ignore_warnings(warnings.catch_warnings):
     Context manager to ignore general warnings using warnings.filterwarnings.
     """
 
-    def __init__(self, *warining_strings: str, **kwargs):
+    def __init__(self, *warning_strings: str, **kwargs):
         super().__init__(**kwargs)
-        self.warning_strings = warining_strings
+        self.warning_strings = warning_strings
 
     def __enter__(self):
         out = super().__enter__()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,11 +75,11 @@ class TestUtils(common_testing.BaseTestCase):
 
     def test_decimal_degrees_to_dms_str(self):
         pairs = [
-            [0, '0°0′0.0000″'],
-            [1, '1°0′0.0000″'],
-            [1.23456789, '1°14′4.4444″'],
+            [0, '0°00′00.0000″'],
+            [1, '1°00′00.0000″'],
+            [1.23456789, '1°14′04.4444″'],
             [-123.456, '-123°27′21.6000″'],
-            [360, '360°0′0.0000″'],
+            [360, '360°00′00.0000″'],
         ]
         for decimal_degrees, dms_str in pairs:
             with self.subTest(decimal_degrees=decimal_degrees):
@@ -87,6 +87,18 @@ class TestUtils(common_testing.BaseTestCase):
                     utils.decimal_degrees_to_dms_str(
                         decimal_degrees, seconds_fmt='.4f'
                     ),
+                    dms_str,
+                )
+        pairs = [
+            [0, '0°00′00″'],
+            [123.46, '123°27′36″'],
+            [123.456, '123°27′21.6″'],
+            [-123.456, '-123°27′21.6″'],
+        ]
+        for decimal_degrees, dms_str in pairs:
+            with self.subTest(decimal_degrees=decimal_degrees):
+                self.assertEqual(
+                    utils.decimal_degrees_to_dms_str(decimal_degrees),
                     dms_str,
                 )
 


### PR DESCRIPTION
Improved formatting of DMS strings returned by `utils.decimal_degrees_to_dms_str`:
- Added zero padding of arcminute and arcsecond parts of the string. This ensures that the integral parts of the arcmin and arcsec parts always have 2 digits, e.g. `01`.
- Changed default formatting for `seconds_fmt` from `''` to `'g'`. This removes unneeded `.0`, ensures consistency between e.g. `decimal_degrees_to_dms_str(1)` and `decimal_degrees_to_dms_str(1.0)` and suppresses minor floating point variations.

This also has the effect of tidying up the RA/Dec values displayed in the GUI Coords tab (see #493), which are created by `decimal_degrees_to_dms_str`.

Old behaviour:
```
      0 -> '0°0′0″'
    0.0 -> '0°0′0.0″'
    0.1 -> '0°6′0.0″'
  1.234 -> '1°14′2.399999999999636″'
 -1.234 -> '-1°14′2.399999999999636″'
123.456 -> '123°27′21.600000000034925″'
```

New behaviour:
```
      0 -> '0°00′00″'
    0.0 -> '0°00′00″'
    0.1 -> '0°06′00″'
  1.234 -> '1°14′02.4″'
 -1.234 -> '-1°14′02.4″'
123.456 -> '123°27′21.6″'
```

Closes #493

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.