### PR TITLE
Replace `utc2et` with `str2et` when parsing date strings

### DIFF
--- a/docs/user_interface.rst
+++ b/docs/user_interface.rst
@@ -28,7 +28,7 @@ These will both open a window where you can then choose a file to open:
     :width: 600
     :alt: User interface window with options to choose which file to open.
 
-If your data is a FITS file, PlanetMapper will attempt to automatically fill the target, date and observer fields for you with information from the FITS header (but it's worth double checking that the values are what you expect). The date should be in a format which `can be understood by SPICE <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/utc2et_c.html#Examples>`_ (such as `YYYY-mm-ddTHH:MM:SS`) and should be in UTC. You can also specify a list of :ref:`SPICE kernels` to load here - if you're unsure then the default values will probably work.
+If your data is a FITS file, PlanetMapper will attempt to automatically fill the target, date and observer fields for you with information from the FITS header (but it's worth double checking that the values are what you expect). The date should be in a format which `can be understood by SPICE <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html#Examples>`_ (such as `YYYY-mm-ddTHH:MM:SS`) and should be in UTC. You can also specify a list of :ref:`SPICE kernels` to load here - if you're unsure then the default values will probably work.
 
 .. hint::
     The target, date and observer fields are passed directly to the `target`, `utc` and `observer` parameters of a :class:`planetmapper.Observation` object, so check the full documentation for :class:`planetmapper.Observation` and :class:`planetmapper.Body` for details of what formats are accepted.

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -822,7 +822,7 @@ class BodyBase(SpiceBase):
         self.observer_frame = observer_frame
         self.aberration_correction = aberration_correction
 
-        self.et = spice.utc2et(utc)
+        self.et = float(spice.str2et(utc))
         self.dtm: datetime.datetime = self.et2dtm(self.et)
         self.utc = self.dtm.strftime(self._DEFAULT_DTM_FORMAT_STRING)
         self.target_body_id: int = spice.bods2c(self.target)

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -300,7 +300,7 @@ class Body(BodyBase):
             assumed to be UTC unless otherwise specified. The accepted formats are: any
             `string` datetime representation compatible with SPICE (e.g.
             `'2000-12-31T23:59:59'` - see the
-            `documentation of acceptable string formats <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/utc2et_c.html>`_),
+            `documentation of acceptable string formats <https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/str2et_c.html>`_),
             a Python `datetime` object, or a `float` representing the Modified Julian
             Date (MJD) of the observation. Alternatively, if `utc` is `None` (the
             default), then the current time is used.

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -2402,7 +2402,7 @@ class OpenObservation(Popup):
             )  #  type: ignore
         except ValueError:
             try:
-                spice.utc2et(observation_kwargs['utc'])  #  type: ignore
+                spice.str2et(observation_kwargs['utc'])  #  type: ignore
             # pylint: disable-next=broad-except
             except Exception as e:
                 self.show_spice_warning(title='Error parsing date', exception=e)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -656,28 +656,31 @@ class TestBodyBase(common_testing.BaseTestCase):
         obj = BodyBase(utc='2005-01-01 12:00', **kw)
         self.assertEqual(obj.utc, '2005-01-01T12:00:00.000000')
 
-        self.assertEqual(
-            obj,
-            BodyBase(utc=datetime.datetime(2005, 1, 1, 12), **kw),
-        )
-        self.assertEqual(
-            obj,
-            BodyBase(utc=53371.5, **kw),
-        )
-
-        self.assertEqual(
-            obj,
-            BodyBase(
-                utc=datetime.datetime(
-                    2005,
-                    1,
-                    1,
-                    15,
-                    tzinfo=datetime.timezone(datetime.timedelta(hours=3)),
-                ),
-                **kw,
+        equivalent_utcs = [
+            datetime.datetime(2005, 1, 1, 12),
+            datetime.datetime(
+                2005, 1, 1, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=3))
             ),
-        )
+            53371.5,
+            '2005-01-01T12:00',
+            '2005-01-01T12:00:00',
+            '2005-01-01T12:00:00.000',
+            '2005-01-01T12:00:00.000000',
+            '2005-01-01T12:00:00.000000Z',
+            '2005 January 1 12:00',
+            '2005-01-01 12:00 UTC',
+            '2005-01-01 11:00 UTC-1',
+            '2005-01-01 23:12 UTC+11:12',
+        ]
+        for utc in equivalent_utcs:
+            with self.subTest(utc=utc):
+                obj_test = BodyBase(utc=utc, **kw)
+                self.assertEqual(obj_test, obj)
+                self.assertEqual(obj_test.utc, '2005-01-01T12:00:00.000000')
+                self.assertEqual(
+                    obj_test.dtm,
+                    datetime.datetime(2005, 1, 1, 12, tzinfo=datetime.timezone.utc),
+                )
 
         class CustomDateTime(datetime.datetime):
             pass


### PR DESCRIPTION
Replace SPICE calls to `utc2et` with `str2et`, as recommended by the [SPICE documentation](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/utc2et_c.html). This allows users to now also specify timezone information in strings provided to e.g. `Body`, such as `'2005-01-01 11:00 UTC-1'`. All previously accepted time strings should still be accepted with no changes needed.

Internally, this is a simple like-for-like replacement of function calls, with associated changes to the documentation.

Closes #498

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.