### PR TITLE
Change copy coordinates shortcut in GUI from `Ctrl+C` to `C`

### DIFF
--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -257,8 +257,8 @@ class GUI:
             self.decrease_radius: ['-', '_'],
             self.save_button: ['<Control-s>'],
             self.load_observation: ['<Control-o>'],
-            self.copy_machine_coord_values: ['<Control-c>'],
-            self.copy_formatted_coord_values: ['<Control-Shift-C>'],
+            self.copy_machine_coord_values: ['c'],
+            self.copy_formatted_coord_values: ['<Shift-C>'],
             self.display_header: ['<Control-h>'],
         }
         self.shortcuts_to_keep_in_entry = ['<Control-s>', '<Control-o>']
@@ -1561,14 +1561,14 @@ class GUI:
             pass
 
     def copy_formatted_coord_values(self) -> None:
-        self.copy_to_clipboard(self.coords_formatted_str)
+        if self.coords_formatted_str is not None:
+            self.copy_to_clipboard(self.coords_formatted_str)
 
     def copy_machine_coord_values(self) -> None:
-        self.copy_to_clipboard(self.coords_machine_str)
+        if self.coords_machine_str is not None:
+            self.copy_to_clipboard(self.coords_machine_str)
 
-    def copy_to_clipboard(self, s: str | None) -> None:
-        if s is None:
-            s = ''
+    def copy_to_clipboard(self, s: str) -> None:
         self.root.clipboard_clear()
         self.root.clipboard_append(s)
 


### PR DESCRIPTION
Changed the copy coordinates shortcut in the GUI from `Ctrl+C` to just be `C`. Previously, this `Ctrl+C` prevented text from being copied from entry widgets in the GUI, which could be annoying if you wanted to use the numbers elsewhere. With this change, `Ctrl+C` can be safely used to copy selected text, and `C` can be used to copy the coordinates for the click location.

Similarly changed the associated copy formatted coordinates shortcut from `Ctrl+Shift+C` to `Shift+C`. 

This PR also updates the `GUI.copy...coord_values` methods to only actually update the clipboard if there is a click location in the GUI. Previously, if there was no click location, these methods would simply copy an empty string to the clipboard, but now, if there is no click location, the clipboard is not changed.

Closes #504

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.