### PR TITLE
Improve robustness against crashes by attempting to switch to the `tkagg` Matplotlib backend before running the GUI 

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -105,6 +105,7 @@ RA/Dec wireframe plots appear split into two halves
 ===================================================
 If the target body is near RA=0°, the `wireframe plot may appear to be split into two halves <https://github.com/ortk95/planetmapper/issues/326#issuecomment-1934275816>`_, due to part of the body having RA values near 0° and part having RA values near 360°. This can be fixed by using `body.plot_wireframe_radec(use_shifted_meridian=True)`, which will plot the wireframe with RA coordinates between -180° and 180°, rather than the default of 0° to 360°.
 
+.. _ssh errors:
 
 SSH Errors
 ==========
@@ -131,3 +132,27 @@ As a temporary workaround, you can set the `PLANETMAPPER_USE_X11_FONT_BUGFIX` en
     export PLANETMAPPER_USE_X11_FONT_BUGFIX=true
 
 This tells the PlanetMapper user interface to replace certain characters with ASCII equivalents (e.g. `↑` is replaced with `^`) which seems to prevent the use of the fonts which cause XQuartz to crash. Note that this will make the user interface slightly more ugly, but should not affect functionality. If you are still having issues after trying this workaround, you can `add a comment to the GitHub issue <https://github.com/ortk95/planetmapper/issues/145>`_.
+
+
+.. _matplotlib backend error:
+
+Matplotlib backend `ImportError` when running the graphical user interface
+==========================================================================
+If you get an error like `ImportError: Cannot load backend 'tkagg' which requires the 'tk' interactive framework, as 'macosx' is currently running`, then Matplotlib is choosing a configuration that is incompatible with the PlanetMapper Graphical User Interface (GUI).
+
+To fix this, you can manually set the `Matplotlib backend <https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend>`_ to `tkagg` before creating any plots. This will ensure that Matplotlib uses a backend compatible with the PlanetMapper GUI, preventing any conflicts. You can do this by adding `matplotlib.use('tkagg')` to the top of your script, before creating any plots: ::
+
+    import matplotlib
+    import matplotlib.pyplot as plt
+    import planetmapper
+
+    matplotlib.use('tkagg')
+
+    observation = planetmapper.Observation('data.fits')
+    plt.imshow(observation.data[0])
+
+    observation.run_gui()
+
+See the `Matplotlib documentation <https://matplotlib.org/stable/users/explain/figure/backends.html#selecting-a-backend>`_ for more information on how to set the backend.
+
+This issue occurs if your system defaults to a Matplotlib backend incompatible with the Tk-based PlanetMapper GUI and you create any Matplotlib plots before running the GUI in the same script. For example, this can happen on macOS systems, where the default `macosx` Matplotlib backend is not compatible with Tk. Normally, Matplotlib automatically attempts to choose a backend compatible with other libraries (like PlanetMapper), but Matplotlib's automatic selection is less reliable when creating plots then subsequently running other GUI code, so manually setting the backend with `matplotlib.use('tkagg')` can be necessary to ensure compatibility. See `this issue on the Matplotlib GitHub <https://github.com/matplotlib/matplotlib/issues/30388>`_ for more details.

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -4,8 +4,7 @@
 **************
 
 .. hint::
-   See also the :ref:`page of examples <python examples>` of using the PlanetMapper Python package
-
+   See also the :ref:`page of examples <python examples>` of using the PlanetMapper Python package and the :ref:`list of common issues & solutions <common issues>`.
 
 .. automodule:: planetmapper
    :show-inheritance:

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -1571,7 +1571,8 @@ class Observation(BodyXY):
 
 
         See the :ref:`graphical user interface tutorial <gui examples>` for more details
-        about the GUI.
+        about the GUI. Note that running the PlanetMapper GUI may change the Matplotlib
+        backend to `tkagg` if it is not already set to a compatible backend.
 
         .. note ::
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import common_testing
+import matplotlib.backends.registry
 
 import planetmapper
 import planetmapper.gui
@@ -10,8 +11,10 @@ from planetmapper.gui import GUI
 
 
 class TestFunctions(common_testing.BaseTestCase):
+    def setUp(self) -> None:
+        planetmapper.set_kernel_path(common_testing.KERNEL_PATH)
 
-    @patch('planetmapper.gui.GUI', autospec=True)
+    @patch('planetmapper.gui.GUI')
     def test_run_gui(self, mock_GUI: MagicMock):
 
         mock_gui_instance = MagicMock()
@@ -31,7 +34,86 @@ class TestFunctions(common_testing.BaseTestCase):
             planetmapper.Observation(path)
         )
 
+    @patch('matplotlib.pyplot.switch_backend')
+    @patch('matplotlib.backends.backend_registry.resolve_backend')
+    @patch('matplotlib.get_backend')
+    def test_maybe_switch_matplotlib_backend_to_tkagg(
+        self,
+        mock_get_backend: MagicMock,
+        mock_resolve_backend: MagicMock,
+        mock_switch_backend: MagicMock,
+    ):
+        registry = matplotlib.backends.registry.BackendRegistry()
+
+        def resolve_backend(backend):
+            try:
+                return registry.resolve_backend(backend)
+            except RuntimeError:
+                if backend == 'inline':
+                    # Treat inline as a headless backend if it isn't available on the
+                    # current system.
+                    return backend, None
+                raise
+
+        mock_resolve_backend.side_effect = resolve_backend
+
+        gui_backends_to_test = [
+            'tkagg',
+            'TkAgg',
+            'tkcairo',
+            'gtk3agg',
+            'qtagg',
+            'wx',
+            'macosx',
+        ]
+        headless_backends_to_test = [
+            'agg',
+            'cairo',
+            'pdf',
+            'svg',
+            'inline',
+        ]
+        for backend in gui_backends_to_test + headless_backends_to_test:
+            with self.subTest('Success', backend=backend):
+                mock_get_backend.return_value = backend
+                mock_switch_backend.reset_mock()
+                planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg()
+                if backend.lower() == 'tkagg' or backend in headless_backends_to_test:
+                    mock_switch_backend.assert_not_called()
+                else:
+                    mock_switch_backend.assert_called_once_with('tkagg')
+
+        mock_switch_backend.reset_mock()
+        for backend in gui_backends_to_test + headless_backends_to_test:
+            with self.subTest('Failure', backend=backend):
+                mock_get_backend.return_value = backend
+                mock_switch_backend.reset_mock()
+                msg_to_raise = (
+                    'Cannot load backend {!r} which requires the {!r} interactive '
+                    'framework, as {!r} is currently running'.format(
+                        'tkagg', '???', backend
+                    )
+                )
+                mock_switch_backend.side_effect = ImportError(msg_to_raise)
+                if backend.lower() == 'tkagg' or backend in headless_backends_to_test:
+                    planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg()
+                    mock_switch_backend.assert_not_called()
+                else:
+                    with self.assertRaises(ImportError) as cm:
+                        planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg()
+                    msg_caught = str(cm.exception)
+                    self.assertIn(msg_caught, msg_caught)
+                    self.assertIn(planetmapper.gui._BACKEND_ERROR_HELP_TEXT, msg_caught)
+                    mock_switch_backend.assert_called_once_with('tkagg')
+
 
 class TestGUI(common_testing.BaseTestCase):
-    def test_init(self):
+
+    @patch('planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg')
+    def test_init(self, mock_maybe_switch_backend: MagicMock):
         GUI()
+        mock_maybe_switch_backend.assert_called_once()
+
+        mock_maybe_switch_backend.reset_mock()
+        GUI(check_matplotlib_backend=False)
+        mock_maybe_switch_backend.assert_not_called()

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1149,8 +1149,10 @@ class TestObservation(common_testing.BaseTestCase):
                         else:
                             self.assertEqual(value, value_ref)
 
+    @patch('planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg')
     @patch('planetmapper.gui.GUI.run')
-    def test_run_gui(self, mock_run: MagicMock):
+    def test_run_gui(self, mock_run: MagicMock, mock_maybe_switch_backend: MagicMock):
         out = self.observation.run_gui()
         self.assertEqual(out, [])
         mock_run.assert_called_once()
+        mock_maybe_switch_backend.assert_called_once()


### PR DESCRIPTION
Previously, Python could crash if you ran the PlanetMapper GUI while also using Matplotlib with a non-tkagg GUI backend. This was due to the PlanetMapper Tk event loop conflicting with the other event loop, causing a hard-to-diagnose and unrecoverable crash.

PlanetMapper now attempts to switch to a Tk backend using `plt.switch_backend('tkagg')` before running the GUI. This will either:
- Succeed, in which case there the GUI can be run cleanly (basically the existing behaviour)
- Fail with an ImportError, which we catch, annotate (pointing to the docs) and re-raise. This error can be handled with other Python code (try/except), rather than the previous hard crashes which were unrecoverable.

If Matplotlib is running with a non-GUI backend (e.g. Jupyter's `inline`), then we do not call `plt.switch_backend`, as there will be no conflicting event loop, and wherever possible we want the backend to remain unchanged for other Python code.

This has been implemented by checking the backend in `GUI.__init__`, although this check can be disabled with `GUI(check_matplotlib_backend=False)` if desired. Have also added appropriate documentation to the common issues page (which is referenced by the raised ImportError), and notes about maybe changing the backend to e.g. the `run_gui` functions.

Closes #508

### Pull request checklist
- [ ] Add a clear description of the change
- [ ] Add any new tests needed
- [ ] Run spell check on new text visible to user (documentation, GUI etc.)
- [ ] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [ ] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.