### PR TITLE
Use `ruff` to format source code, rather than `black` and `isort`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,11 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "black"
-          - "isort"
+          - "ruff"
           - "pyright"
           - "pylint"
           - "coverage"
+          - "setuptools"
+          - "packaging"
           - "sphinx"
           - "sphinx_rtd_theme"
-          - "setuptools"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ name: Checks
 on: [push, pull_request, workflow_call]
 
 jobs:
-  black:
+  ruff-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,26 +16,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r dev_requirements.txt
-      - name: Run Black
+      - name: Run Ruff Formatter
         run: |
-          black . --check --diff
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: "pip"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r dev_requirements.txt
-      - name: Run isort
-        run: |
-          isort . --check --diff
+          ruff format . --check --diff
   
   pyright:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Each individual pull request should be limited to a single new feature or bug fi
 Pull requests should generally target the `dev` branch, which is where new features are developed.
 
 Contributions must pass all checks before they will be merged, and conform to the the style of existing code. You can run the checks locally using `run_checks.sh` to make sure that:
-- All code is correctly formatted using `black` and `isort`
+- All code is correctly formatted using `ruff format`
 - The code passes `pylint` and `pyright` checks
 - The code passes all tests (on your OS & Python version)
 

--- a/check_docstring_version_directives.py
+++ b/check_docstring_version_directives.py
@@ -8,6 +8,7 @@ when it is written, even if the next version number is currently unknown. This s
 will then catch the missing version directive and remind the developer to update the
 version directive before releasing a new version.
 """
+
 import sys
 from pathlib import Path
 from typing import Sequence

--- a/check_for_todo_comments.py
+++ b/check_for_todo_comments.py
@@ -6,6 +6,7 @@ Check Python files for TODO comments.
 This checks for TODO comments in the planetmapper source code and tests, then prints
 the found comments.
 """
+
 import sys
 from pathlib import Path
 from typing import Sequence

--- a/check_release_version.py
+++ b/check_release_version.py
@@ -3,6 +3,7 @@
 """
 Check GitHub tag version is equal to planetmapper.__version__.
 """
+
 import os
 import sys
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,6 +1,5 @@
-# Developemnt requirements (e.g. for run_checks.sh)
-black==25.1.0
-isort==6.0.1
+# Development requirements (e.g. for run_checks.sh)
+ruff==0.12.10
 pyright==1.1.403
 pylint==3.3.7
 coverage==7.10.1

--- a/examples/general_python_api.py
+++ b/examples/general_python_api.py
@@ -6,6 +6,7 @@ https://planetmapper.readthedocs.io/en/latest/general_python_api.html
 
 Run download_spice_kernels() to download the kernels required for these examples.
 """
+
 import os
 import sys
 

--- a/examples/make_logos.py
+++ b/examples/make_logos.py
@@ -5,6 +5,7 @@ Create various logos for PlanetMapper
 
 Run download_spice_kernels() to download the kernels required to generate the logos.
 """
+
 import os
 import sys
 

--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -749,7 +749,9 @@ class SpiceBase:
             # the op_dtypes argument ensures that the output arrays are floats, as
             # otherwise we could end up with e.g. int arrays which would then truncate
             # values, potentially leading to errors
-            with np.nditer([arg1, arg2, None, None], op_dtypes=[None, None, float, float]) as it:  # type: ignore
+            with np.nditer(
+                [arg1, arg2, None, None], op_dtypes=[None, None, float, float]
+            ) as it:  # type: ignore
                 for a, b, u, v in it:
                     u[...], v[...] = func(a, b, *args, **kwargs)  #  type: ignore
                 return it.operands[2], it.operands[3]  #  type: ignore

--- a/planetmapper/data/scrape_ring_radii.py
+++ b/planetmapper/data/scrape_ring_radii.py
@@ -6,6 +6,7 @@ https://nssdc.gsfc.nasa.gov/planetary/factsheet
 
 The printed output from running this file can be used in rings.json
 """
+
 import html
 import json
 import urllib.request

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -29,8 +29,10 @@ from astropy.io import fits
 from matplotlib.artist import Artist
 from matplotlib.backend_bases import MouseButton, MouseEvent
 from matplotlib.backends import backend_registry  # type: ignore
-from matplotlib.backends.backend_tkagg import NavigationToolbar2Tk  # type: ignore
-from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
+from matplotlib.backends.backend_tkagg import (
+    FigureCanvasTkAgg,
+    NavigationToolbar2Tk,  # type: ignore
+)
 from matplotlib.figure import Figure
 from matplotlib.text import Text
 
@@ -2539,9 +2541,7 @@ class OpenObservation(Popup):
             return False
 
         try:
-            observation_kwargs['utc'] = float(
-                observation_kwargs['utc']
-            )  #  type: ignore
+            observation_kwargs['utc'] = float(observation_kwargs['utc'])  #  type: ignore
         except ValueError:
             try:
                 spice.str2et(observation_kwargs['utc'])  #  type: ignore
@@ -3163,11 +3163,13 @@ class SavingProgress(Popup):
             self.window.title('Cancelled saving files')
             if self.save_nav and not save_nav_done:
                 self.nav_widgets['message'].configure(
-                    text='Cancelled', foreground='red3'  # type: ignore
+                    text='Cancelled',  # type: ignore
+                    foreground='red3',  # type: ignore
                 )
             if self.save_map and not save_map_done:
                 self.map_widgets['message'].configure(
-                    text='Cancelled', foreground='red3'  # type: ignore
+                    text='Cancelled',  # type: ignore
+                    foreground='red3',  # type: ignore
                 )
         finally:
             self.is_running_save = False

--- a/planetmapper/kernel_downloader.py
+++ b/planetmapper/kernel_downloader.py
@@ -24,6 +24,7 @@ These functions can be used to download a set of URLS. For example: ::
     )
 
 """
+
 import os
 import urllib.parse
 import urllib.request
@@ -81,7 +82,7 @@ def download_kernels_from_webpage(index_url: str, **kwargs) -> None:
     urls = get_kernel_paths_from_webpage(index_url)
     print(f'{len(urls)} to download from {index_url}')
     for idx, url in enumerate(urls):
-        download_kernel(url, note=f'[{idx+1}/{len(urls)}] ', **kwargs)
+        download_kernel(url, note=f'[{idx + 1}/{len(urls)}] ', **kwargs)
     print(f'All kernels downloaded from {index_url}')
     print()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,8 @@
-[tool.black]
-skip-string-normalization = true
-exclude = ""
-# Manually set exclude="" to prevent black using .gitignore due
-# to black not parsing trailing slashes in .gitignore correctly
-# https://github.com/psf/black/issues/3694
-extend-exclude = "python-type-stubs"
+[tool.ruff]
+extend-exclude = ["python-type-stubs"]
 
-
-[tool.isort]
-profile = "black"
-extend_skip = ["python-type-stubs"]
+[tool.ruff.format]
+quote-style = "preserve"
 
 
 [tool.coverage.run]

--- a/run_checks.sh
+++ b/run_checks.sh
@@ -22,13 +22,12 @@ pip install -r requirements.txt -r dev_requirements.txt --dry-run | grep "Would 
 
 # Allow the docstring/tests check to fail (end line with ";"), all others should
 # cause the script to stop (end lines with "&&"), as the docstring check only
-# really matters when we are releasing a new version, so it's normal for it to
+# really matters when we are releasing a new version, so it's normal for it to
 # fail when the next version number is currently unknown.
 echo -e "\nChecking documentation version directives..." && python check_docstring_version_directives.py;
 echo -e "\nChecking for TODO comments..." && python check_for_todo_comments.py;
 
-echo -e "\nRunning black..." && black . --check --diff && \
-echo -e "\nRunning isort..." && isort . --check --diff && \
+echo -e "\nRunning ruff format..." && ruff format . --check --diff && \
 echo -e "\nRunning pyright..." && pyright && \
 echo -e "\nRunning pylint..." && pylint $(git ls-files 'planetmapper/*.py') setup.py check_release_version.py && \
 echo -e "\nRunning tests..." && python -m coverage run -m unittest discover -s tests && python -m coverage report && python -m coverage html && \

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -273,7 +273,8 @@ class TestSpiceBase(common_testing.BaseTestCase):
             with self.subTest(v):
                 self.assertAlmostEqual(self.obj.vector_magnitude(v), magnitude)
                 self.assertAlmostEqual(
-                    self.obj.vector_magnitude(v), np.linalg.norm(v)  # type: ignore
+                    self.obj.vector_magnitude(v),
+                    np.linalg.norm(v),  # type: ignore
                 )
 
         self.assertTrue(np.isnan(self.obj.vector_magnitude(np.array([1, np.nan]))))

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -974,15 +974,15 @@ class TestBodyXY(common_testing.BaseTestCase):
                 [100.0, -100.0, 100.0, -100.0, 100.0, nan],
             ]
         )
+        # fmt: off
         expected_interpolations: dict[str | int | tuple[int, int], list] = {
-            # fmt: off
             'nearest': [[nan, nan, 100.0, 100.0, -1.0, nan, nan, nan], [nan, nan, nan, 75.0, 999.0, 3.3, 3.3, nan], [nan, nan, nan, 0.0, 123.45, nan, 123.456789, nan], [nan, nan, nan, 3.0, 3.0, 0.1, nan, nan]],
             'linear': [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 61.591824124152424, 488.0893412811879, 4.181692402514696, nan, nan], [nan, nan, nan, 3.678385742930187, 94.03788871233297, nan, nan, nan], [nan, nan, nan, -25.28910210942658, -1.6502703714050462, nan, nan, nan]],
             'quadratic': [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 47.43961193970507, 780.1933190874719, -11.958641161828965, nan, nan], [nan, nan, nan, -40.33639788223132, 106.33548747800452, nan, nan, nan], [nan, nan, nan, -35.84554405305129, -19.35757229218872, nan, nan, nan]],
             'cubic': [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 38.17050096080083, 837.0682797065551, -40.810161294299334, nan, nan], [nan, nan, nan, -77.21287210436617, 103.88323214798433, nan, nan, nan], [nan, nan, nan, -29.994884067130222, -35.81550582449343, nan, nan, nan]],
             (1, 2): [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 48.82728713390978, 584.7164003757379, -0.9895987798646678, nan, nan], [nan, nan, nan, -0.625402661173368, 99.24054961575526, nan, nan, nan], [nan, nan, nan, -33.19407454333914, -8.380623602166663, nan, nan, nan]],
-            # fmt: on
         }
+        # fmt: on
         for interpolation, expected_img in expected_interpolations.items():
             with self.subTest(interpolation=interpolation):
                 self.assertArraysClose(
@@ -1050,12 +1050,12 @@ class TestBodyXY(common_testing.BaseTestCase):
                 )
 
         # NaN propagation
+        # fmt: off
         expected_propagations: dict[bool, list] = {
-            # fmt: off
             True: [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 61.591824124152424, 488.0893412811879, 4.181692402514696, nan, nan], [nan, nan, nan, 3.678385742930187, 94.03788871233297, nan, nan, nan], [nan, nan, nan, -25.28910210942658, -1.6502703714050462, nan, nan, nan]],
             False: [[nan, nan, 83.42502054006614, 61.410255547165704, 1.0972142916279704, nan, nan, nan], [nan, nan, nan, 61.591824124152424, 488.0893412811879, 4.181692402514696, 3.8032713799190443, nan], [nan, nan, nan, 3.678385742930187, 94.03788871233297, 35.721226497463014, 94.00305287602345, nan], [nan, nan, nan, -25.28910210942658, -1.6502703714050462, 4.265385156596395, nan, nan]],
-            # fmt: on
         }
+        # fmt: on
         for propagate_nan, expected_img in expected_propagations.items():
             with self.subTest(propagate_nan=propagate_nan):
                 self.assertArraysClose(
@@ -1069,14 +1069,14 @@ class TestBodyXY(common_testing.BaseTestCase):
                 )
 
         # Check smoothing
+        # fmt: off
         expected_smoothings: dict[float, list] = {
-            # fmt: off
             0: [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 61.591824124152424, 488.0893412811879, 4.181692402514696, nan, nan], [nan, nan, nan, 3.678385742930187, 94.03788871233297, nan, nan, nan], [nan, nan, nan, -25.28910210942658, -1.6502703714050462, nan, nan, nan]],
             1: [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 61.78601266274162, 487.8146612006081, 4.182606695966389, nan, nan], [nan, nan, nan, 3.7096818751834397, 94.00272821072134, nan, nan, nan], [nan, nan, nan, -25.261262121302103, -1.6266437631103958, nan, nan, nan]],
             2.345: [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 61.88924454749024, 487.6685543716773, 4.183100640730575, nan, nan], [nan, nan, nan, 3.726347429765339, 93.98407173080481, nan, nan, nan], [nan, nan, nan, -25.24645740659029, -1.614083382535183, nan, nan, nan]],
             67.89: [[nan, nan, nan, nan, nan, nan, nan, nan], [nan, nan, nan, 63.190326809626086, 485.8219836178685, 4.1898033877049246, nan, nan], [nan, nan, nan, 3.9380925063904084, 93.75102909782771, nan, nan, nan], [nan, nan, nan, -25.05957376720378, -1.4557553087461503, nan, nan, nan]],
-            # fmt: on
         }
+        # fmt: on
         for smoothing, expected_img in expected_smoothings.items():
             with self.subTest(smoothing=smoothing):
                 self.assertArraysClose(

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -16,7 +16,6 @@ class TestFunctions(common_testing.BaseTestCase):
 
     @patch('planetmapper.gui.GUI')
     def test_run_gui(self, mock_GUI: MagicMock):
-
         mock_gui_instance = MagicMock()
         mock_GUI.return_value = mock_gui_instance
 
@@ -108,7 +107,6 @@ class TestFunctions(common_testing.BaseTestCase):
 
 
 class TestGUI(common_testing.BaseTestCase):
-
     @patch('planetmapper.gui._maybe_switch_matplotlib_backend_to_tkagg')
     def test_init(self, mock_maybe_switch_backend: MagicMock):
         GUI()


### PR DESCRIPTION
Use `ruff format` to format the PlanetMapper Python source code, rather than the previous combination of `black` for formatting code and `isort` for sorting imports.

This is pretty much a drop in replacement for black+isort, but with significantly faster performance. There are a few small [formatting differences](https://docs.astral.sh/ruff/formatter/black/) between ruff and isort, but these are incredibly minor (and usually an improvement anyway).

This has no user-facing impact on PlanetMapper (as no code has functionally changed), but PlanetMapper is now a bit easier and quicker to maintain. This also will simplify the process of adding more ruff linting checks in the future if we want to.

Closes #512

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.