### PR TITLE
Add a button to the GUI spectrum popup to copy the plotted data

### DIFF
--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -1,6 +1,7 @@
 # pylint: disable=attribute-defined-outside-init,protected-access
 import functools
 import itertools
+import json
 import math
 import os
 import platform
@@ -1593,9 +1594,12 @@ class GUI:
     def get_click_coords(self) -> dict[str, float]:
         if self.last_click_location is None:
             return {}
+        return self._get_coords_for_location(*self.last_click_location)
+
+    def _get_coords_for_location(self, x: float, y: float) -> dict[str, float]:
         out: dict[str, float] = {}
         observation = self.get_observation()
-        x, y = self.last_click_location
+
         ra, dec = observation.xy2radec(x, y)
         out['x'] = x
         out['y'] = y
@@ -3540,6 +3544,8 @@ class SpectrumPopup(Popup):
         ) = '<UNSET>'
         self._previous_mode_data: tuple[str, int, int, int, int] | None = None
         self._previous_y_scale: Literal['linear', 'log'] | None = None
+        self._previous_width: int | None = None
+
         self._legend_handle: Legend | None = None
         self._image_mode_handles: list[Artist] = []
         self._comparison_spectra_handles: list[Artist] = []
@@ -3576,6 +3582,9 @@ class SpectrumPopup(Popup):
             self.canvas_frame.winfo_height() / self.fig.dpi,
         )
         self.update()
+        self.on_resize()
+
+        self.window.bind('<Configure>', self.on_resize)
 
     def build_plot(self) -> None:
         self.fig = Figure()
@@ -3637,42 +3646,68 @@ class SpectrumPopup(Popup):
         )
 
     def build_controls(self) -> None:
+        self.control_texts: dict[
+            ttk.Checkbutton | ttk.Button, tuple[str, str, int]
+        ] = {}
+
+        def add_short_text_option(
+            widget: ttk.Checkbutton | ttk.Button,
+            short_text: str,
+            *,
+            threshold: int = 675,
+        ) -> None:
+            self.control_texts[widget] = (short_text, widget.cget('text'), threshold)
+
         self.yscale_var = tk.IntVar(value=0)
         self.yscale_var.trace_add('write', self.on_change)
-        self.yscale_checkbox = ttk.Checkbutton(
-            self.controls_frame,
-            text='Log scale',
-            variable=self.yscale_var,
-        )
-        self.yscale_checkbox.pack(side='left', padx=2, ipadx=2)
-        self.gui.add_tooltip(
-            self.yscale_checkbox,
+        self.yscale_checkbox = self.gui.add_tooltip(
+            ttk.Checkbutton(
+                self.controls_frame,
+                text='Log scale',
+                variable=self.yscale_var,
+            ),
             'Toggle logarithmic/linear scale for the plot\'s y-axis',
         )
+        add_short_text_option(self.yscale_checkbox, 'Log')
+        self.yscale_checkbox.pack(side='left', padx=2, ipadx=2)
 
-        self.add_to_compare_button = ttk.Button(
-            self.controls_frame,
-            text='Add to comparisons',
-            command=self.add_current_spectrum_to_compare,
-            padding=(3, 1),
-        )
-        self.add_to_compare_button.pack(side='left', padx=2, ipadx=2)
-        self.gui.add_tooltip(
-            self.add_to_compare_button,
+        self.add_to_compare_button = self.gui.add_tooltip(
+            ttk.Button(
+                self.controls_frame,
+                text='Add to comparisons',
+                width=0,
+                command=self.add_current_spectrum_to_compare,
+                padding=(3, 1),
+            ),
             'Keep the currently displayed spectrum on the plot to allow comparison with other spectra',
         )
+        add_short_text_option(self.add_to_compare_button, 'Add')
+        self.add_to_compare_button.pack(side='left', padx=(2, 0), ipadx=2)
 
-        self.reset_comparisons_button = ttk.Button(
-            self.controls_frame,
-            text='Clear comparisons',
-            command=self.reset_comparisons,
-            padding=(3, 1),
-        )
-        self.reset_comparisons_button.pack(side='left', padx=2, ipadx=2)
-        self.gui.add_tooltip(
-            self.reset_comparisons_button,
+        self.reset_comparisons_button = self.gui.add_tooltip(
+            ttk.Button(
+                self.controls_frame,
+                text='Reset',
+                width=0,
+                command=self.reset_comparisons,
+                padding=(3, 1),
+            ),
             'Clear all comparison spectra from the plot',
         )
+        self.reset_comparisons_button.pack(side='left', padx=(0, 2), ipadx=2)
+
+        self.copy_data_button = self.gui.add_tooltip(
+            ttk.Button(
+                self.controls_frame,
+                text='Copy data',
+                width=0,
+                command=self.copy_data_to_clipboard,
+                padding=(3, 1),
+            ),
+            'Copy the currently displayed spectral data to the clipboard in machine readable JSON format',
+        )
+        add_short_text_option(self.copy_data_button, 'Copy')
+        self.copy_data_button.pack(side='left', padx=2, ipadx=2)
 
     def get_wavelengths(self) -> tuple[np.ndarray, str, bool]:
         wavelengths = self.gui._observation_wavelengths
@@ -3885,6 +3920,77 @@ class SpectrumPopup(Popup):
     def close_window(self, *_) -> None:
         super().close_window()
         self.update_comparison_markers_on_gui()
+
+    def on_resize(self, *_) -> None:
+        def func():
+            # Check popup still exists
+            if self.gui._spectrum_popup is not None:
+                self.gui._spectrum_popup._on_resize_window()
+
+        self.gui.add_delayed_action('on_resize_spectrum_popup', 1, func)
+
+    def _on_resize_window(self) -> None:
+        self.resize_texts()
+
+    def resize_texts(self) -> None:
+        current_width = self.window.winfo_width()
+        if current_width == self._previous_width:
+            return
+        self._previous_width = current_width
+
+        for widget, (sort_text, long_text, threshold) in self.control_texts.items():
+            widget.configure(text=sort_text if current_width < threshold else long_text)
+
+    def copy_data_to_clipboard(self) -> None:
+        self.gui.copy_to_clipboard(self._get_copyable_data_json_string())
+
+    def _get_copyable_data_json_string(self) -> str:
+        spectra_data_lines: list[str] = []
+        for click_location, color in self.comparison_coordinates_and_colors:
+            spectra_data_lines.append(
+                self._get_copyable_data_for_spectrum(click_location)
+            )
+        if self.line.get_visible():
+            spectra_data_lines.append(
+                self._get_copyable_data_for_spectrum(self.gui.last_click_location)
+            )
+
+        data: dict[str, str] = {}
+        data['description'] = json.dumps('Spectral data exported from PlanetMapper')
+        data['observation'] = json.dumps(
+            self.gui.get_observation().get_description(multiline=False)
+        )
+        if self.gui.get_observation().path is not None:
+            data['path'] = json.dumps(self.gui.get_observation().path)
+        if self.is_real_wavelengths:
+            data['wavelengths'] = self._dump_array(self.wavelengths)
+        data['spectra'] = (
+            '[' + ', '.join('\n    ' + line for line in spectra_data_lines) + '\n  ]'
+        )
+        data['planetmapper_version'] = json.dumps(common.__version__)
+        return '{' + ', '.join(f'\n  "{k}": {v}' for k, v in data.items()) + '\n}'
+
+    def _get_copyable_data_for_spectrum(
+        self, click_location: tuple[float, float] | None
+    ) -> str:
+        data: dict[str, str] = {}
+        data['label'] = json.dumps(
+            self._get_label_and_title_from_click_location(click_location)[0].replace(
+                '\u00b0', ''
+            )
+        )
+        if click_location is not None:
+            x, y = self.round_xy_to_indices(*click_location)
+            coords = self.gui._get_coords_for_location(x, y)
+            formatted_string = self.gui.make_click_json_string(
+                coords, fmt='', fmt_radec=''
+            )
+            data['location'] = formatted_string  # already JSON, so no need for dumps
+        data['spectrum'] = self._dump_array(self.get_spectrum(click_location))
+        return '{' + ', '.join(f'"{k}": {v}' for k, v in data.items()) + '}'
+
+    def _dump_array(self, array: np.ndarray) -> str:
+        return json.dumps([(float(v) if np.isfinite(v) else None) for v in array])
 
 
 # Artist settings popups


### PR DESCRIPTION
Added a button to the spectrum popup in the user interface that copies the plotted spectral data to the clipboard. The data is copied in a machine-readable JSON format, and contains the data and metadata for all the spectra currently plotted in the popup. This is a logical extension to the existing `Copy machine readable values` button in the Coords tab.

Example spectrum popup and associated copied data:

<img width="912" height="540" alt="image" src="https://github.com/user-attachments/assets/1f028fb0-6daf-49ba-817b-757556cedbdb" />

```json
{
  "description": "Spectral data exported from PlanetMapper", 
  "observation": "URANUS (799) from JAMES WEBB SPACE TELESCOPE at 2026-01-03 22:31 UTC", 
  "path": "/Users/ortk2/Dropbox/science/jwst_data/NIRSPEC_IFU/2026_Uranus/visit01_lon1/stage3/d1/Level3_g395h-f290lp_s3d_nav.fits", 
  "wavelengths": [2.870332385558868, 2.8709973855584394, 2.871662385558011, 2.8723273855575826, 2.872992385557154, 2.873657385556726, 2.8743223855562974, 2.874987385555869, 2.8756523855554406, 2.876317385555012, 2.8769823855545837, 2.8776473855541553, 2.878312385553727, 2.8789773855532985, 2.87964238555287, 2.8803073855524417, 2.8809723855520133, 2.881637385551585, 2.8823023855511565, 2.882967385550728, 2.8836323855502997, 2.8842973855498713, 2.884962385549443, 2.8856273855490144, ...],
  "spectra": [
    {"label": "Cube average", "spectrum": [58.4425048828125, 67.94440460205078, 81.54411315917969, 90.66533660888672, 99.6182861328125, 105.05055236816406, 104.35247802734375, 101.01725006103516, 89.57633972167969, 60.057533264160156, 44.86410903930664, 66.91181182861328, 92.76316833496094, 103.43047332763672, 108.07951354980469, 110.4221420288086, 109.81031036376953, 103.71082305908203, 85.51611328125, 56.60977554321289, 37.31282424926758, 43.02565002441406, 70.04008483886719, ...]},
    {"label": "x=23, y=8 (20.3E, 76.5N)", "location": {"xy": [23, 8], "radec": [55.25661200955433, 19.410470006901786], "lonlat": [20.317451808931192, 76.48386087806281], "lonlat_centric": [20.317451808931192, 75.86726558936418], "phase": 2.086307574638322, "incidence": 7.870101908275589, "emission": 9.215504761944215, "azimuth": 169.21706816042445, "limb_distance": -21692.40916923082}, "spectrum": [166.88804626464844, 169.68655395507812, 223.3756103515625, 240.65077209472656,  ...]},
    {"label": "x=15, y=15 (97.9E, 56.5N)", "location": {"xy": [15, 15], "radec": [55.256616690019975, 19.410174973727653], "lonlat": [97.86931286653972, 56.462320671031925], "lonlat_centric": [97.86931286653972, 55.22760478287948], "phase": 2.0863077587696606, "incidence": 28.38334504436208, "emission": 29.31101663965015, "azimuth": 176.12578336113148, "limb_distance": -12883.377878242094}, "spectrum": [114.20304870605469, 128.27828979492188, 148.60755920410156, 180.2669219970703,  ...]},
    {"label": "x=6, y=26", "location": {"xy": [6, 26], "radec": [55.25669206767311, 19.40978692431364], "limb_distance": 5808.035693272628, "ring_radius": 31423.55691112452}, "spectrum": [6.605903148651123, 5.626689434051514, 6.092103481292725, 8.630304336547852, 7.31816291809082, 3.788297414779663, 7.305649757385254, 6.980774879455566, 4.728809356689453, 4.950549602508545, 3.8524458408355713, 4.800814151763916, 6.913143157958984, 6.049250602722168, 6.479742050170898, 6.1399407386779785,  ...]}
  ], 
  "planetmapper_version": "1.13.4"
}
```
(long lists have been truncated for readability in this example)

The exported data contains metadata about PlanetMapper and the observation, a wavelength array (if any FITS header contains wavelength WCS info), and a list of spectra. Each spectrum entry contains a label, coordinates for any click location (in an identical format to the output of `Copy machine readable values`), and the spectral data array. In arrays, any non finite values (e.g. NaN, Infinity) are replaced with `null`.

The JSON data can easily be loaded into other software, e.g. [with Python](https://docs.python.org/3/library/json.html).

Closes #574

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.