### PR TITLE
Change the default value of `not_visible_nan` to `True` in `lonlat2...` methods

### DIFF
--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -1066,7 +1066,7 @@ class Body(BodyBase):
         lat: FloatOrArray,
         *,
         alt: float = 0.0,
-        not_visible_nan: bool = False,
+        not_visible_nan: bool = True,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `RA/Dec
@@ -1082,13 +1082,16 @@ class Body(BodyBase):
             lon: Planetographic longitude of point(s) on target body.
             lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
-            not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
-                the point is not visible to the observer (e.g. it is on the far side of
-                the target). If `False` (the default), then `(ra, dec)` coordinates will
-                be returned, even if the point is not directly visible.
+            not_visible_nan: If `True` (the default), then the returned RA/Dec values
+                will be NaN if the point is not visible to the observer (e.g. it is on
+                the far side of the target). If `False`, then `(ra, dec)` coordinates
+                will be returned, even if the point is not directly visible.
 
         Returns:
             `(ra, dec)` tuple containing the RA/Dec coordinates of the point(s).
+
+        .. versionchanged:: ?.?.?
+            The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
             self._lonlat2radec, lon, lat, alt=alt, not_visible_nan=not_visible_nan
@@ -1166,10 +1169,12 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
-            not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
-                the point is not visible to the observer (e.g. it is on the far side of
-                the target). If `False` (the default), then `(ra, dec)` coordinates will
-                be returned, even if the point is not directly visible.
+            not_visible_nan: If `True`, then the returned vector will be all NaN if the
+                point is not visible to the observer (e.g. it is on the far side of the
+                target). If `False` (the default), then the coordinate vector will be
+                returned be returned, even if the point is not directly visible. Note
+                that `not_visible_nan` defaults to `False` here, whereas it defaults to
+                `True` in methods such as :func:`lonlat2radec`.
 
         Returns:
             Numpy array corresponding to the 3D rectangular vector describing the
@@ -1466,7 +1471,7 @@ class Body(BodyBase):
         lat: FloatOrArray,
         *,
         alt: float = 0.0,
-        not_visible_nan: bool = False,
+        not_visible_nan: bool = True,
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
@@ -1483,10 +1488,10 @@ class Body(BodyBase):
             lon: Planetographic longitude of point(s) on target body.
             lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
-            not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
-                the point is not visible to the observer (e.g. it is on the far side of
-                the target). If `False` (the default), then `(ra, dec)` coordinates will
-                be returned, even if the point is not directly visible.
+            not_visible_nan: If `True` (the default), then the returned values will be
+                NaN if the point is not visible to the observer (e.g. it is on the far
+                side of the target). If `False`, then `(angular_x, angular_y)`
+                coordinates will be returned, even if the point is not directly visible.
             **angular_kwargs: Additional arguments are used to customise the origin and
                 rotation of the relative angular coordinates. See
                 :func:`radec2angular` for details.
@@ -1494,6 +1499,9 @@ class Body(BodyBase):
         Returns:
             `(angular_x, angular_y)` tuple containing the relative angular coordinates
             of the point(s) in arcseconds.
+
+        .. versionchanged:: ?.?.?
+            The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
             self._lonlat2angular,
@@ -1650,7 +1658,7 @@ class Body(BodyBase):
         lat: FloatOrArray,
         *,
         alt: float = 0.0,
-        not_visible_nan: bool = False,
+        not_visible_nan: bool = True,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `distance
@@ -1666,14 +1674,17 @@ class Body(BodyBase):
             lon: Planetographic longitude of point(s) on target body.
             lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
-            not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
-                the point is not visible to the observer (e.g. it is on the far side of
-                the target). If `False` (the default), then `(ra, dec)` coordinates will
-                be returned, even if the point is not directly visible.
+            not_visible_nan: If `True` (the default), then the returned values will be
+                NaN if the point is not visible to the observer (e.g. it is on the far
+                side of the target). If `False`, then `(km_x, km_y)` coordinates will be
+                returned, even if the point is not directly visible.
 
         Returns:
             `(km_x, km_y)` tuple containing distances in km in the target plane in the
             East-West and North-South directions respectively.
+
+        .. versionchanged:: ?.?.?
+            The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
             self._lonlat2km, lon, lat, alt=alt, not_visible_nan=not_visible_nan
@@ -2790,7 +2801,9 @@ class Body(BodyBase):
         Returns:
             Angle of the north pole in degrees (-180 to 180).
         """
-        np_x, np_y = self.radec2angular(*self.lonlat2radec(0, 90))
+        np_x, np_y = self.radec2angular(
+            *self.lonlat2radec(0, 90, not_visible_nan=False)
+        )
         target_x, target_y = self.radec2angular(self.target_ra, self.target_dec)
         theta = -np.arctan2(target_x - np_x, np_y - target_y)
         theta = np.rad2deg(theta) % 360.0
@@ -3112,12 +3125,16 @@ class Body(BodyBase):
 
             if label_poles:
                 for lon, lat, s in self.get_poles_to_plot():
-                    x, y = coordinate_func(*self.lonlat2radec(lon, lat))
+                    x, y = coordinate_func(
+                        *self.lonlat2radec(lon, lat, not_visible_nan=False)
+                    )
                     ax.text(x, y, s, **kwargs['pole'])
 
             for lon, lat in self.coordinates_of_interest_lonlat:
                 if self.test_if_lonlat_visible(lon, lat):
-                    x, y = coordinate_func(*self.lonlat2radec(lon, lat))
+                    x, y = coordinate_func(
+                        *self.lonlat2radec(lon, lat, not_visible_nan=False)
+                    )
                     ax.scatter(x, y, **kwargs['coordinate_of_interest_lonlat'])
             for ra, dec in self.coordinates_of_interest_radec:
                 ax.scatter(

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -480,7 +480,7 @@ class BodyXY(Body):
         lat: FloatOrArray,
         *,
         alt: float = 0.0,
-        not_visible_nan: bool = False,
+        not_visible_nan: bool = True,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `image pixel
@@ -496,13 +496,16 @@ class BodyXY(Body):
             lon: Planetographic longitude of point(s) on target body.
             lat: Planetographic latitude of point(s) on target body.
             alt: Altitude of point above the surface of the target body in km.
-            not_visible_nan: If `True`, then the returned RA/Dec values will be NaN if
-                the point is not visible to the observer (e.g. it is on the far side of
-                the target). If `False` (the default), then `(ra, dec)` coordinates will
-                be returned, even if the point is not directly visible.
+            not_visible_nan: If `True` (the default), then the returned x/y values will
+                be NaN if the point is not visible to the observer (e.g. it is on the
+                far side of the target). If `False`, then `(x, y)` coordinates will be
+                returned, even if the point is not directly visible.
 
         Returns:
             `(x, y)` tuple containing the image pixel coordinates of the point(s).
+
+        .. versionchanged:: ?.?.?
+            The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
             self._lonlat2xy, lon, lat, alt=alt, not_visible_nan=not_visible_nan

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -2063,7 +2063,9 @@ class GUI:
     def replot_poles(self):
         self.remove_artists('pole')
         for lon, lat, s in self.get_observation().get_poles_to_plot():
-            ra, dec = self.get_observation().lonlat2radec(lon, lat)
+            ra, dec = self.get_observation().lonlat2radec(
+                lon, lat, not_visible_nan=False
+            )
             self.plot_handles['pole'].append(
                 self.ax.add_artist(
                     OutlinedText(

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -10,7 +10,7 @@ import common_testing
 import matplotlib.pyplot as plt
 import numpy as np
 import spiceypy as spice
-from numpy import array, nan
+from numpy import array, inf, nan
 from spiceypy.utils.exceptions import (
     NotFoundError,
     SpiceBODIESNOTDISTINCT,
@@ -654,7 +654,11 @@ class TestBody(common_testing.BaseTestCase):
         for lonlat, radec in pairs:
             with self.subTest(lonlat):
                 self.assertTrue(
-                    np.allclose(self.body.lonlat2radec(*lonlat), radec, equal_nan=True)
+                    np.allclose(
+                        self.body.lonlat2radec(*lonlat, not_visible_nan=False),
+                        radec,
+                        equal_nan=True,
+                    )
                 )
 
         pairs_with_alts: list[
@@ -668,7 +672,7 @@ class TestBody(common_testing.BaseTestCase):
         for (lon, lat, alt), expected in pairs_with_alts:
             with self.subTest((lon, lat, alt)):
                 self.assertArraysClose(
-                    self.body.lonlat2radec(lon, lat, alt=alt),
+                    self.body.lonlat2radec(lon, lat, alt=alt, not_visible_nan=False),
                     expected,
                     equal_nan=True,
                 )
@@ -687,12 +691,7 @@ class TestBody(common_testing.BaseTestCase):
             equal_nan=True,
         )
         self.assertArraysClose(
-            self.body.lonlat2radec(
-                [[0, 90, 123], [100, 200, 300.123]],
-                0,
-                alt=123.456,
-                not_visible_nan=True,
-            ),
+            self.body.lonlat2radec([[0, 90, 123], [100, 200, 300.123]], 0, alt=123.456),
             (
                 array(
                     [
@@ -717,13 +716,70 @@ class TestBody(common_testing.BaseTestCase):
             equal_nan=True,
         )
         self.assertArraysClose(
-            self.body.lonlat2radec([np.nan, np.inf, 0, 1.234, 1234], 0),
+            self.body.lonlat2radec(
+                [np.nan, np.inf, 0, 1.234, 1234], 0, not_visible_nan=False
+            ),
             (
                 array([nan, nan, 196.3698279, 196.36974134, 196.37215256]),
                 array([nan, nan, -5.56506094, -5.56501974, -5.56561021]),
             ),
             equal_nan=True,
         )
+
+        # lonlat, radec(not_visible_nan=True), radec(not_visible_nan=False)
+        not_visible_nan_coordinates: list[
+            tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+        ] = [
+            ((0, 90), (nan, nan), (196.37390490466322, -5.561534444253402)),
+            (
+                (0, -90),
+                (196.3700662953778, -5.570053261753392),
+                (196.3700662953778, -5.570053261753392),
+            ),
+            ((0, 0), (nan, nan), (196.36982789576643, -5.565060944053696)),
+            ((-42.123, -42.123), (nan, nan), (196.37159471956562, -5.569112859340856)),
+            (
+                (123.45, 42.123),
+                (196.37155730609302, -5.562127656859109),
+                (196.37155730609302, -5.562127656859109),
+            ),
+            ((nan, nan), (nan, nan), (nan, nan)),
+            ((inf, inf), (nan, nan), (nan, nan)),
+            ((0, nan), (nan, nan), (nan, nan)),
+            ((nan, 0), (nan, nan), (nan, nan)),
+        ]
+        for (
+            lonlat,
+            radec_not_visible_true,
+            radec_not_visible_false,
+        ) in not_visible_nan_coordinates:
+            with self.subTest(
+                'not_visible_nan=<DEFAULT>',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2radec(*lonlat),
+                    radec_not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=True',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2radec(*lonlat, not_visible_nan=True),
+                    radec_not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=False',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2radec(*lonlat, not_visible_nan=False),
+                    radec_not_visible_false,
+                    equal_nan=True,
+                )
 
     def test_radec2lonlat(self):
         self.assertTrue(
@@ -1008,7 +1064,7 @@ class TestBody(common_testing.BaseTestCase):
         for (lon, lat, alt), expected in pairs_with_alts:
             with self.subTest((lon, lat, alt)):
                 self.assertArraysClose(
-                    self.body.lonlat2angular(lon, lat, alt=alt),
+                    self.body.lonlat2angular(lon, lat, alt=alt, not_visible_nan=False),
                     expected,
                     equal_nan=True,
                 )
@@ -1032,6 +1088,60 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertArraysClose(
                     self.body.angular2lonlat(x, y, alt=alt), expected, equal_nan=True
                 )
+        # lonlat, not_visible_nan=True, not_visible_nan=False
+        not_visible_nan_coordinates: list[
+            tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+        ] = [
+            ((0, 90), (nan, nan), (-6.876884688222162, 15.333839200239979)),
+            (
+                (0, -90),
+                (6.876958825091606, -15.333903800125292),
+                (6.876958825091606, -15.333903800125292),
+            ),
+            ((0, 0), (nan, nan), (7.7312107002171615, 2.6384369710660938)),
+            ((-42.123, -42.123), (nan, nan), (1.400614489898544, -11.948444406821393)),
+            (
+                (123.45, 42.123),
+                (1.534685475508013, 13.19828443451154),
+                (1.534685475508013, 13.19828443451154),
+            ),
+            ((nan, nan), (nan, nan), (nan, nan)),
+            ((inf, inf), (nan, nan), (nan, nan)),
+            ((0, nan), (nan, nan), (nan, nan)),
+            ((nan, 0), (nan, nan), (nan, nan)),
+        ]
+        for (
+            lonlat,
+            not_visible_true,
+            not_visible_false,
+        ) in not_visible_nan_coordinates:
+            with self.subTest(
+                'not_visible_nan=<DEFAULT>',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2angular(*lonlat),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=True',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2angular(*lonlat, not_visible_nan=True),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=False',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2angular(*lonlat, not_visible_nan=False),
+                    not_visible_false,
+                    equal_nan=True,
+                )
 
     def test_km_rotation(self):
         x_target, y_target = self.body.radec2km(
@@ -1041,7 +1151,7 @@ class TestBody(common_testing.BaseTestCase):
         self.assertAlmostEqual(y_target, 0)
         for lat in [-90, 90]:
             with self.subTest(lat):
-                x, y = self.body.lonlat2km(0, lat)
+                x, y = self.body.lonlat2km(0, lat, not_visible_nan=False)
                 self.assertAlmostEqual(x, x_target, delta=1)
                 if lat > 0:
                     self.assertGreater(y, y_target)
@@ -1125,7 +1235,7 @@ class TestBody(common_testing.BaseTestCase):
         for (lon, lat, alt), expected in pairs_with_alts:
             with self.subTest((lon, lat, alt)):
                 self.assertArraysClose(
-                    self.body.lonlat2km(lon, lat, alt=alt),
+                    self.body.lonlat2km(lon, lat, alt=alt, not_visible_nan=False),
                     expected,
                     equal_nan=True,
                 )
@@ -1148,6 +1258,61 @@ class TestBody(common_testing.BaseTestCase):
             with self.subTest((x, y, alt)):
                 self.assertArraysClose(
                     self.body.km2lonlat(x, y, alt=alt), expected, equal_nan=True
+                )
+
+        # lonlat, not_visible_nan=True, not_visible_nan=False
+        not_visible_nan_coordinates: list[
+            tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+        ] = [
+            ((0, 90), (nan, nan), (-1.433363649994135e-09, 66779.52199294537)),
+            (
+                (0, -90),
+                (0.16375935621545068, -66779.87677061002),
+                (0.16375935621545068, -66779.87677061002),
+            ),
+            ((0, 0), (nan, nan), (32321.992189846314, -3005.186949276849)),
+            ((-42.123, -42.123), (nan, nan), (-14350.827719310022, -45599.95768245907)),
+            (
+                (123.45, 42.123),
+                (27025.925086085685, 45358.56586021766),
+                (27025.925086085685, 45358.56586021766),
+            ),
+            ((nan, nan), (nan, nan), (nan, nan)),
+            ((inf, inf), (nan, nan), (nan, nan)),
+            ((0, nan), (nan, nan), (nan, nan)),
+            ((nan, 0), (nan, nan), (nan, nan)),
+        ]
+        for (
+            lonlat,
+            not_visible_true,
+            not_visible_false,
+        ) in not_visible_nan_coordinates:
+            with self.subTest(
+                'not_visible_nan=<DEFAULT>',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2km(*lonlat),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=True',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2km(*lonlat, not_visible_nan=True),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=False',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2km(*lonlat, not_visible_nan=False),
+                    not_visible_false,
+                    equal_nan=True,
                 )
 
     def test_km_angular(self):

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -376,7 +376,7 @@ class TestBodyXY(common_testing.BaseTestCase):
         for (lon, lat, alt), expected in pairs_with_alts:
             with self.subTest((lon, lat, alt)):
                 self.assertArraysClose(
-                    self.body.lonlat2xy(lon, lat, alt=alt),
+                    self.body.lonlat2xy(lon, lat, alt=alt, not_visible_nan=False),
                     expected,
                     equal_nan=True,
                 )
@@ -400,6 +400,61 @@ class TestBodyXY(common_testing.BaseTestCase):
             with self.subTest((x, y, alt)):
                 self.assertArraysClose(
                     self.body.xy2lonlat(x, y, alt=alt), expected, equal_nan=True
+                )
+
+        # lonlat, not_visible_nan=True, not_visible_nan=False
+        not_visible_nan_coordinates: list[
+            tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+        ] = [
+            ((0, 90), (nan, nan), (5.997148396961149, 10.618837276380527)),
+            (
+                (0, -90),
+                (4.002852727532121, 5.381146365350973),
+                (4.002852727532121, 5.381146365350973),
+            ),
+            ((0, 0), (nan, nan), (6.2226715347443555, 7.399517739761713)),
+            ((-42.123, -42.123), (nan, nan), (3.7563192307429167, 6.426030001593531)),
+            (
+                (123.45, 42.123),
+                (6.737145127998048, 9.375239631269238),
+                (6.737145127998048, 9.375239631269238),
+            ),
+            ((nan, nan), (nan, nan), (nan, nan)),
+            ((inf, inf), (nan, nan), (nan, nan)),
+            ((0, nan), (nan, nan), (nan, nan)),
+            ((nan, 0), (nan, nan), (nan, nan)),
+        ]
+        for (
+            lonlat,
+            not_visible_true,
+            not_visible_false,
+        ) in not_visible_nan_coordinates:
+            with self.subTest(
+                'not_visible_nan=<DEFAULT>',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2xy(*lonlat),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=True',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2xy(*lonlat, not_visible_nan=True),
+                    not_visible_true,
+                    equal_nan=True,
+                )
+            with self.subTest(
+                'not_visible_nan=False',
+                lonlat=lonlat,
+            ):
+                self.assertArraysClose(
+                    self.body.lonlat2xy(*lonlat, not_visible_nan=False),
+                    not_visible_false,
+                    equal_nan=True,
                 )
 
     def test_set_disc_params(self):


### PR DESCRIPTION
In all `lonlat2...` coordinate conversion methods, changed the default value of the `not_visible_nan` argument from `False` to `True`. This means that (in the default case), coordinate conversions where the provided longitude/latitude coordinates are not visible will return `(nan, nan)`. This should help avoid any confusion where e.g. previously `lonlat2xy` would provide pixel coordinates for a location on the target that is not actually visible in the observation.

```python
# New function signature
def lonlat2...(longitude, latitude, *, not_visible_nan=True): ...

# Old function signature
def lonlat2...(longitude, latitude, *, not_visible_nan=False): ...
```

This is only a change to the default, so the previous behavior can be restored by explicitly passing `not_visible_nan=False`. For example:

```python
# Same output as before for locations that are visible, but will now return (nan, nan) for locations that are not visible:
body.lonlat2xy(lon, lat)

# Same output as previous behavior, returning finite values even if the location is not visible:
body.lonlat2xy(lon, lat, not_visible_nan=False)
```

This change also helps to ensure that, by default, coordinate conversions are more invertible. E.g. previously `xy2lonlat(*lonlat2xy(lon, lat))` could produce confusing results when the input longitude/latitude is at the back of the planet. With the new update, it should return the input longitude/latitude coordinates (with some small floating point variation) if the location is visible, or `(nan, nan)` if the location is not visible.

This update explicitly does _not_ change the default value of `not_visible_nan` in `lonlat2targvec`, which remains as `lonlat2targvec(lon, lat, *, not_visible_nan=False`. This is because the 3D targvec coordinate system does not have the same ambiguity as the 2D coordinate systems (radec, xy, ...) for locations that are not visible, and is therefore less tied to the observer's POV. Added a note to the docstring of `lonlat2targvec` to point out this difference.

Closes #535 

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.