### PR TITLE
Allow methods accepting or returning longitudes/latitudes to use planetocentric coordinates with a new `planetocentric` parameter 

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -73,6 +73,11 @@ This is likely to be due to an issue with your SPICE kernels or settings, possib
 - If you are using WCS information saved in the FITS header to automatically set the disc position, note that telescope pointing information (i.e. the WCS information) is never perfect. For example, due to the errors in guide star tracking, JWST pointing is only accurate to ~0.5".
 
 
+Latitude/longitude coordinates seem incorrect
+=============================================
+There are two main conventions used for latitude/longitude coordinates: planetographic and planetocentric. PlanetMapper uses the planetographic coordinates by default, but you can specify the planetocentric coordinates by setting the `planetocentric` keyword argument to `True` when calling the relevant methods (e.g. :func:`planetmapper.Body.radec2lonlat`). See the :ref:`longitude/latitude coordinate documentation <longitude/latitude coordinates>` for more information.
+
+
 .. _readonly arrays:
 
 Read-only NumPy arrays

--- a/docs/general_python_api.rst
+++ b/docs/general_python_api.rst
@@ -65,6 +65,15 @@ If you are interested in features above (or below) the target's nominal surface,
 
     ra, dec = body.lonlat2radec(lon, lat, alt=100)  # position of a feature at altitude of 100 km
 
+PlanetMapper defaults to using planetographic :ref:`longitude/latitude coordinates <longitude/latitude coordinates>`, but you would rather work with planetocentric coordinates, then most longitude/latitude functions have an optional `planetocentric` parameter: ::
+
+    body.lonlat2radec(lon, lat)  # lon/lat are planetographic
+    body.lonlat2radec(lon, lat, planetocentric=True)  # lon/lat are planetocentric
+
+    body.radec2lonlat(ra, dec)  # returns planetographic lon/lat
+    body.radec2lonlat(ra, dec, planetocentric=True)  # returns planetocentric lon/lat
+
+
 .. hint::
     The main classes in PlanetMapper are subclasses of each other, with :class:`planetmapper.SpiceBase` the parent class of :class:`planetmapper.Body` which is the parent of :class:`planetmapper.BodyXY` which is the parent of :class:`planetmapper.Observation`. 
     

--- a/planetmapper/__init__.py
+++ b/planetmapper/__init__.py
@@ -45,15 +45,19 @@ for more details. The surface altitude can also be customised with the `alt` par
 for example, `body.lonlat2radec(12, 34, alt=1000)` will calculate the RA/Dec coordinates
 of the point at planetographic coordinates (12, 34) and with an altitude of 1000 km.
 
-If planetocentric longitude/latitude coordinates are desired, then functions
-:func:`Body.graphic2centric_lonlat` and :func:`Body.centric2graphic_lonlat` can be used
-to convert between planetographic and planetocentric coordinates: ::
+If you would rather work with planetocentric coordinates, then most functions accepting
+or returning longitude/latitude coordinates have an optional `planetocentric` parameter:
+::
 
-    # Use planetocentric coordinates as inputs to PlanetMapper methods
-    radec = body.lonlat2radec(*body.centric2graphic_lonlat(12, 34), alt=1000)
+    body.lonlat2radec(lon, lat)  # lon/lat are planetographic
+    body.lonlat2radec(lon, lat, planetocentric=True)  # lon/lat are planetocentric
 
-    # Convert PlanetMapper lonlat outputs to planetocentric coordinates
-    lonlat_centric = body.graphic2centric_lonlat(*body.radec2lonlat(12, 34))
+    body.radec2lonlat(ra, dec)  # returns planetographic lon/lat
+    body.radec2lonlat(ra, dec, planetocentric=True)  # returns planetocentric lon/lat
+
+You can also use the functions :func:`Body.graphic2centric_lonlat` and
+:func:`Body.centric2graphic_lonlat` to directly convert between planetographic and
+planetocentric coordinates.
 
 ----
 

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -888,7 +888,12 @@ class Body(BodyBase):
 
     # Coordinate transformations target -> observer direction
     def _lonlat2targvec_radians(
-        self, lon: float, lat: float, *, alt: float, not_visible_nan: bool
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float,
+        not_visible_nan: bool,
     ) -> np.ndarray:
         """
         Transform lon/lat coordinates on body to rectangular vector in target frame.
@@ -1032,8 +1037,16 @@ class Body(BodyBase):
 
     # Useful transformations (built from combinations of above transformations)
     def _lonlat2obsvec(
-        self, lon: float, lat: float, *, alt: float, not_visible_nan: bool
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float,
+        not_visible_nan: bool,
+        planetocentric: bool,
     ) -> np.ndarray:
+        if planetocentric:
+            lon, lat = self.centric2graphic_lonlat(lon, lat, alt=alt)
         return self._targvec2obsvec(
             self._lonlat2targvec_radians(
                 *self._degree_pair2radians(lon, lat),
@@ -1043,7 +1056,12 @@ class Body(BodyBase):
         )
 
     def _obsvec_norm2lonlat(
-        self, obsvec_norm: np.ndarray, not_found_nan: bool, alt: float
+        self,
+        obsvec_norm: np.ndarray,
+        *,
+        not_found_nan: bool,
+        alt: float,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         with _AdjustedSurfaceAltitude(self, alt):
             try:
@@ -1058,6 +1076,8 @@ class Body(BodyBase):
                     lat = np.nan
                 else:
                     raise
+            if planetocentric:
+                lon, lat = self.graphic2centric_lonlat(lon, lat, alt=alt)
             return lon, lat
 
     def lonlat2radec(
@@ -1067,6 +1087,7 @@ class Body(BodyBase):
         *,
         alt: float = 0.0,
         not_visible_nan: bool = True,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `RA/Dec
@@ -1086,6 +1107,9 @@ class Body(BodyBase):
                 will be NaN if the point is not visible to the observer (e.g. it is on
                 the far side of the target). If `False`, then `(ra, dec)` coordinates
                 will be returned, even if the point is not directly visible.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             `(ra, dec)` tuple containing the RA/Dec coordinates of the point(s).
@@ -1094,14 +1118,31 @@ class Body(BodyBase):
             The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
-            self._lonlat2radec, lon, lat, alt=alt, not_visible_nan=not_visible_nan
+            self._lonlat2radec,
+            lon,
+            lat,
+            alt=alt,
+            not_visible_nan=not_visible_nan,
+            planetocentric=planetocentric,
         )
 
     def _lonlat2radec(
-        self, lon: float, lat: float, *, alt: float, not_visible_nan: bool
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float,
+        not_visible_nan: bool,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         return self._obsvec2radec(
-            self._lonlat2obsvec(lon, lat, alt=alt, not_visible_nan=not_visible_nan)
+            self._lonlat2obsvec(
+                lon,
+                lat,
+                alt=alt,
+                not_visible_nan=not_visible_nan,
+                planetocentric=planetocentric,
+            )
         )
 
     def radec2lonlat(
@@ -1111,6 +1152,7 @@ class Body(BodyBase):
         *,
         not_found_nan: bool = True,
         alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `RA/Dec celestial coordinates`_ for the observer to `longitude/latitude
@@ -1135,6 +1177,9 @@ class Body(BodyBase):
                 are missing the target body.
             alt: Altitude of returned `(lon, lat)` point above the surface of the target
                 body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat)` tuple containing the planetographic longitude/latitude
@@ -1147,18 +1192,38 @@ class Body(BodyBase):
                 body and `not_found_nan` is False, then NotFoundError will be raised.
         """
         return self._maybe_transform_as_arrays(
-            self._radec2lonlat, ra, dec, not_found_nan=not_found_nan, alt=alt
+            self._radec2lonlat,
+            ra,
+            dec,
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def _radec2lonlat(
-        self, ra: float, dec: float, *, not_found_nan: bool, alt: float
+        self,
+        ra: float,
+        dec: float,
+        *,
+        not_found_nan: bool,
+        alt: float,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         return self._obsvec_norm2lonlat(
-            self._radec2obsvec_norm(ra, dec), not_found_nan, alt
+            self._radec2obsvec_norm(ra, dec),
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def lonlat2targvec(
-        self, lon: float, lat: float, *, alt: float = 0.0, not_visible_nan: bool = False
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float = 0.0,
+        not_visible_nan: bool = False,
+        planetocentric: bool = False,
     ) -> np.ndarray:
         """
         Convert `longitude/latitude coordinates`_ on the target body to rectangular
@@ -1175,11 +1240,16 @@ class Body(BodyBase):
                 returned be returned, even if the point is not directly visible. Note
                 that `not_visible_nan` defaults to `False` here, whereas it defaults to
                 `True` in methods such as :func:`lonlat2radec`.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             Numpy array corresponding to the 3D rectangular vector describing the
             longitude/latitude point in the target frame of reference.
         """
+        if planetocentric:
+            lon, lat = self.centric2graphic_lonlat(lon, lat, alt=alt)
         return self._lonlat2targvec_radians(
             *self._degree_pair2radians(lon, lat),
             alt=alt,
@@ -1187,7 +1257,7 @@ class Body(BodyBase):
         )
 
     def targvec2lonlat(
-        self, targvec: np.ndarray, *, alt: float = 0.0
+        self, targvec: np.ndarray, *, alt: float = 0.0, planetocentric: bool = False
     ) -> tuple[float, float]:
         """
         Convert rectangular vector centred in the target frame to `longitude/latitude
@@ -1198,13 +1268,19 @@ class Body(BodyBase):
             targvec: 3D rectangular vector in the target frame of reference.
             alt: Altitude of returned `(lon, lat)` point above the surface of the target
                 body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat)` tuple containing the planetographic longitude/latitude
             corresponding to the input vector.
         """
         with _AdjustedSurfaceAltitude(self, alt):
-            return self._radian_pair2degrees(*self._targvec2lonlat_radians(targvec))
+            lon, lat = self._radian_pair2degrees(*self._targvec2lonlat_radians(targvec))
+            if planetocentric:
+                lon, lat = self.graphic2centric_lonlat(lon, lat)
+            return lon, lat
 
     def _targvec_arr2radec_arrs_radians(
         self,
@@ -1408,6 +1484,7 @@ class Body(BodyBase):
         *,
         not_found_nan: bool = True,
         alt: float = 0.0,
+        planetocentric: bool = False,
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
@@ -1427,6 +1504,9 @@ class Body(BodyBase):
                 coordinates are missing the target body.
             alt: Altitude of returned `(lon, lat)` point above the surface of the target
                 body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
             **angular_kwargs: Additional arguments are used to customise the origin and
                 rotation of the relative angular coordinates. See
                 :func:`radec2angular` for details.
@@ -1447,6 +1527,7 @@ class Body(BodyBase):
             angular_y,
             not_found_nan=not_found_nan,
             alt=alt,
+            planetocentric=planetocentric,
             **angular_kwargs,
         )
 
@@ -1457,12 +1538,14 @@ class Body(BodyBase):
         *,
         not_found_nan: bool,
         alt: float,
+        planetocentric: bool,
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         return self._obsvec_norm2lonlat(
             self._angular2obsvec_norm(angular_x, angular_y, **angular_kwargs),
-            not_found_nan,
-            alt,
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def lonlat2angular(
@@ -1472,6 +1555,7 @@ class Body(BodyBase):
         *,
         alt: float = 0.0,
         not_visible_nan: bool = True,
+        planetocentric: bool = False,
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
@@ -1492,6 +1576,9 @@ class Body(BodyBase):
                 NaN if the point is not visible to the observer (e.g. it is on the far
                 side of the target). If `False`, then `(angular_x, angular_y)`
                 coordinates will be returned, even if the point is not directly visible.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
             **angular_kwargs: Additional arguments are used to customise the origin and
                 rotation of the relative angular coordinates. See
                 :func:`radec2angular` for details.
@@ -1509,6 +1596,7 @@ class Body(BodyBase):
             lat,
             alt=alt,
             not_visible_nan=not_visible_nan,
+            planetocentric=planetocentric,
             **angular_kwargs,
         )
 
@@ -1519,10 +1607,17 @@ class Body(BodyBase):
         *,
         alt: float,
         not_visible_nan: bool,
+        planetocentric: bool,
         **angular_kwargs: Unpack[AngularCoordinateKwargs],
     ) -> tuple[float, float]:
         return self._obsvec2angular(
-            self._lonlat2obsvec(lon, lat, alt=alt, not_visible_nan=not_visible_nan),
+            self._lonlat2obsvec(
+                lon,
+                lat,
+                alt=alt,
+                not_visible_nan=not_visible_nan,
+                planetocentric=planetocentric,
+            ),
             **angular_kwargs,
         )
 
@@ -1612,6 +1707,7 @@ class Body(BodyBase):
         *,
         not_found_nan: bool = True,
         alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `distance coordinates`_ in target plane to `longitude/latitude
@@ -1630,6 +1726,9 @@ class Body(BodyBase):
                 coordinates are missing the target body.
             alt: Altitude of returned `(lon, lat)` point above the surface of the target
                 body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat)` tuple containing planetographic longitude/latitude of the
@@ -1642,14 +1741,28 @@ class Body(BodyBase):
             and `not_found_nan` is False, then NotFoundError will be raised.
         """
         return self._maybe_transform_as_arrays(
-            self._km2lonlat, km_x, km_y, not_found_nan=not_found_nan, alt=alt
+            self._km2lonlat,
+            km_x,
+            km_y,
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def _km2lonlat(
-        self, km_x: float, km_y: float, *, not_found_nan: bool, alt: float
+        self,
+        km_x: float,
+        km_y: float,
+        *,
+        not_found_nan: bool,
+        alt: float,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         return self._obsvec_norm2lonlat(
-            self._km2obsvec_norm(km_x, km_y), not_found_nan, alt
+            self._km2obsvec_norm(km_x, km_y),
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def lonlat2km(
@@ -1659,6 +1772,7 @@ class Body(BodyBase):
         *,
         alt: float = 0.0,
         not_visible_nan: bool = True,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `distance
@@ -1678,6 +1792,9 @@ class Body(BodyBase):
                 NaN if the point is not visible to the observer (e.g. it is on the far
                 side of the target). If `False`, then `(km_x, km_y)` coordinates will be
                 returned, even if the point is not directly visible.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             `(km_x, km_y)` tuple containing distances in km in the target plane in the
@@ -1687,14 +1804,31 @@ class Body(BodyBase):
             The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
-            self._lonlat2km, lon, lat, alt=alt, not_visible_nan=not_visible_nan
+            self._lonlat2km,
+            lon,
+            lat,
+            alt=alt,
+            not_visible_nan=not_visible_nan,
+            planetocentric=planetocentric,
         )
 
     def _lonlat2km(
-        self, lon: float, lat: float, *, alt: float, not_visible_nan: bool
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float,
+        not_visible_nan: bool,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         return self._obsvec2km(
-            self._lonlat2obsvec(lon, lat, alt=alt, not_visible_nan=not_visible_nan)
+            self._lonlat2obsvec(
+                lon,
+                lat,
+                alt=alt,
+                not_visible_nan=not_visible_nan,
+                planetocentric=planetocentric,
+            )
         )
 
     def km2angular(
@@ -1878,13 +2012,18 @@ class Body(BodyBase):
                     dec_day[idx] = np.nan
             return ra_day, dec_day, ra_night, dec_night
 
-    def limb_lonlat(self, alt: float = 0.0, **kwargs) -> tuple[np.ndarray, np.ndarray]:
+    def limb_lonlat(
+        self, alt: float = 0.0, planetocentric: bool = False, **kwargs
+    ) -> tuple[np.ndarray, np.ndarray]:
         """
         Calculate the `longitude/latitude coordinates`_ of the target body's limb.
 
         Args:
             npts: Number of points in the generated limb.
             alt: Altitude of the limb above the surface of the target body, in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat)` tuple of planetographic longitude/latitude arrays.
@@ -1892,14 +2031,19 @@ class Body(BodyBase):
         with _AdjustedSurfaceAltitude(self, alt):
             lons, lats = zip(
                 *(
-                    self.targvec2lonlat(targvec)
+                    self.targvec2lonlat(targvec, planetocentric=planetocentric)
                     for targvec in self._limb_targvec(**kwargs)
                 )
             )
             return np.array(lons), np.array(lats)
 
     def limb_coordinates_from_radec(
-        self, ra: float, dec: float, *, alt: float = 0.0
+        self,
+        ra: float,
+        dec: float,
+        *,
+        alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> tuple[float, float, float]:
         """
         Calculate the coordinates relative to the target body's limb for given
@@ -1913,6 +2057,9 @@ class Body(BodyBase):
             dec: Declination of point in the sky of the observer.
             alt: Altitude of the reference limb above the surface of the target body, in
                 km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat, dist)` tuple of coordinates relative to the target body's limb.
@@ -1924,10 +2071,12 @@ class Body(BodyBase):
             disc).
         """
         with _AdjustedSurfaceAltitude(self, alt):
-            coords = self._limb_coordinates_from_obsvec(
+            lon, lat, dist = self._limb_coordinates_from_obsvec(
                 self._radec2obsvec_norm_radians(*self._degree_pair2radians(ra, dec))
             )
-            return coords
+            if planetocentric:
+                lon, lat = self.graphic2centric_lonlat(lon, lat)
+            return lon, lat, dist
 
     def _limb_coordinates_from_obsvec(
         self, obsvec_norm: np.ndarray
@@ -2001,7 +2150,12 @@ class Body(BodyBase):
             return True
 
     def test_if_lonlat_visible(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> bool:
         """
         Test if `longitude/latitude coordinates`_ on (or above) the target body is
@@ -2011,12 +2165,16 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             True if the point is visible from the observer, otherwise False.
         """
         return self._test_if_targvec_visible(
-            self.lonlat2targvec(lon, lat, alt=alt), on_surface=alt == 0.0
+            self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric),
+            on_surface=alt == 0.0,
         )
 
     def other_body_los_intercept(
@@ -2135,7 +2293,7 @@ class Body(BodyBase):
         return phase, incdnc, emissn
 
     def illumination_angles_from_lonlat(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self, lon: float, lat: float, *, alt: float = 0.0, planetocentric: bool = False
     ) -> tuple[float, float, float]:
         """
         Calculate the illumination angles of `longitude/latitude coordinates`_ on the
@@ -2145,13 +2303,16 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             `(phase, incidence, emission)` tuple containing the illumination angles in
             degrees.
         """
         phase, incdnc, emissn = self._illumination_angles_from_targvec_radians(
-            self.lonlat2targvec(lon, lat, alt=alt)
+            self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric)
         )
         return np.rad2deg(phase), np.rad2deg(incdnc), np.rad2deg(emissn)
 
@@ -2171,7 +2332,12 @@ class Body(BodyBase):
         return azimuth_radians  # type: ignore
 
     def azimuth_angle_from_lonlat(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> float:
         """
         Calculate the azimuth angle of `longitude/latitude coordinates`_ on the target
@@ -2181,13 +2347,16 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             Azimuth angle in degrees.
         """
         azimuth_radians = self._azimuth_angle_from_gie_radians(
             *self._illumination_angles_from_targvec_radians(
-                self.lonlat2targvec(lon, lat, alt=alt)
+                self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric)
             )
         )
         return np.rad2deg(azimuth_radians)
@@ -2289,6 +2458,7 @@ class Body(BodyBase):
         only_visible: bool = False,
         close_loop: bool = True,
         alt: float = 0.0,
+        planetocentric: bool = False,
         method: str = 'UMBRAL/TANGENT/ELLIPSOID',
         corloc: str = 'ELLIPSOID TERMINATOR',
     ) -> tuple[np.ndarray, np.ndarray]:
@@ -2300,6 +2470,9 @@ class Body(BodyBase):
             npts: Number of points in generated terminator.
             only_visible: Toggle only returning visible part of terminator.
             alt: Altitude adjustment to the surface of the target body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
             close_loop: If True, passes coordinate arrays through :func:`close_loop`
                 (e.g. to enable nicer plotting).
             method, corloc: Passed to SPICE function.
@@ -2315,7 +2488,12 @@ class Body(BodyBase):
             method=method,
             corloc=corloc,
         )
-        lons, lats = zip(*(self.targvec2lonlat(targvec) for targvec in targvecs))
+        lons, lats = zip(
+            *(
+                self.targvec2lonlat(targvec, planetocentric=planetocentric, alt=alt)
+                for targvec in targvecs
+            )
+        )
         return np.array(lons), np.array(lats)
 
     def _terminator_targvec(
@@ -2369,7 +2547,12 @@ class Body(BodyBase):
         return lit
 
     def test_if_lonlat_illuminated(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> bool:
         """
         Test if `longitude/latitude coordinates`_ on the surface of the target body is
@@ -2379,11 +2562,16 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             True if the point is illuminated, otherwise False.
         """
-        return self._test_if_targvec_illuminated(self.lonlat2targvec(lon, lat, alt=alt))
+        return self._test_if_targvec_illuminated(
+            self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric)
+        )
 
     # Rings
     def _ring_coordinates_from_obsvec(
@@ -2668,7 +2856,7 @@ class Body(BodyBase):
         return self._radial_velocity_from_state(*self._state_from_targvec(targvec))
 
     def radial_velocity_from_lonlat(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self, lon: float, lat: float, *, alt: float = 0.0, planetocentric: bool = False
     ) -> float:
         """
         Calculate radial (i.e. line-of-sight) velocity of a point (`longitude/latitude
@@ -2679,16 +2867,19 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             Radial velocity of the point in km/s.
         """
         return self._radial_velocity_from_targvec(
-            self.lonlat2targvec(lon, lat, alt=alt)
+            self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric)
         )
 
     def distance_from_lonlat(
-        self, lon: float, lat: float, *, alt: float = 0.0
+        self, lon: float, lat: float, *, alt: float = 0.0, planetocentric: bool = False
     ) -> float:
         """
         Calculate distance from observer to a point (`longitude/latitude coordinates`_)
@@ -2698,12 +2889,15 @@ class Body(BodyBase):
             lon: Planetographic longitude of point on target body.
             lat: Planetographic latitude of point on target body.
             alt: Altitude of point above the surface of the target body in km.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             Distance of the point in km.
         """
         position, velocity, lt = self._state_from_targvec(
-            self.lonlat2targvec(lon, lat, alt=alt)
+            self.lonlat2targvec(lon, lat, alt=alt, planetocentric=planetocentric)
         )
         return lt * self.speed_of_light()
 

--- a/planetmapper/body.py
+++ b/planetmapper/body.py
@@ -2013,7 +2013,7 @@ class Body(BodyBase):
             return ra_day, dec_day, ra_night, dec_night
 
     def limb_lonlat(
-        self, alt: float = 0.0, planetocentric: bool = False, **kwargs
+        self, alt: float = 0.0, *, planetocentric: bool = False, **kwargs
     ) -> tuple[np.ndarray, np.ndarray]:
         """
         Calculate the `longitude/latitude coordinates`_ of the target body's limb.

--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -436,6 +436,7 @@ class BodyXY(Body):
         *,
         not_found_nan: bool = True,
         alt: float = 0.0,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `image pixel coordinates`_ to `longitude/latitude coordinates`_ on the
@@ -454,6 +455,9 @@ class BodyXY(Body):
                 are missing the target body.
             alt: Altitude of returned `(lon, lat)` point above the surface of the target
                 body in km.
+            planetocentric: If `True`, return planetocentric rather than planetographic
+                longitude/latitude coordinates. The default is `False`, meaning the
+                returned coordinates are planetographic.
 
         Returns:
             `(lon, lat)` tuple containing the planetographic longitude/latitude of
@@ -466,13 +470,29 @@ class BodyXY(Body):
                 body and `not_found_nan` is `False`.
         """
         return self._maybe_transform_as_arrays(
-            self._xy2lonlat, x, y, not_found_nan=not_found_nan, alt=alt
+            self._xy2lonlat,
+            x,
+            y,
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
         )
 
     def _xy2lonlat(
-        self, x: float, y: float, *, not_found_nan: bool, alt: float
+        self,
+        x: float,
+        y: float,
+        *,
+        not_found_nan: bool,
+        alt: float,
+        planetocentric: bool,
     ) -> tuple[float, float]:
-        return self._obsvec_norm2lonlat(self._xy2obsvec_norm(x, y), not_found_nan, alt)
+        return self._obsvec_norm2lonlat(
+            self._xy2obsvec_norm(x, y),
+            not_found_nan=not_found_nan,
+            alt=alt,
+            planetocentric=planetocentric,
+        )
 
     def lonlat2xy(
         self,
@@ -481,6 +501,7 @@ class BodyXY(Body):
         *,
         alt: float = 0.0,
         not_visible_nan: bool = True,
+        planetocentric: bool = False,
     ) -> tuple[FloatOrArray, FloatOrArray]:
         """
         Convert `longitude/latitude coordinates`_ on the target body to `image pixel
@@ -500,6 +521,9 @@ class BodyXY(Body):
                 be NaN if the point is not visible to the observer (e.g. it is on the
                 far side of the target). If `False`, then `(x, y)` coordinates will be
                 returned, even if the point is not directly visible.
+            planetocentric: If `True`, treat the input coordinates as planetocentric
+                rather than planetographic longitude/latitude coordinates. The default
+                is `False`, meaning the input coordinates are planetographic.
 
         Returns:
             `(x, y)` tuple containing the image pixel coordinates of the point(s).
@@ -508,14 +532,31 @@ class BodyXY(Body):
             The default value of `not_visible_nan` was changed from `False` to `True`.
         """
         return self._maybe_transform_as_arrays(
-            self._lonlat2xy, lon, lat, alt=alt, not_visible_nan=not_visible_nan
+            self._lonlat2xy,
+            lon,
+            lat,
+            alt=alt,
+            not_visible_nan=not_visible_nan,
+            planetocentric=planetocentric,
         )
 
     def _lonlat2xy(
-        self, lon: float, lat: float, *, alt: float, not_visible_nan: bool
+        self,
+        lon: float,
+        lat: float,
+        *,
+        alt: float,
+        not_visible_nan: bool,
+        planetocentric: bool,
     ) -> tuple[float, float]:
         return self._obsvec2xy(
-            self._lonlat2obsvec(lon, lat, alt=alt, not_visible_nan=not_visible_nan)
+            self._lonlat2obsvec(
+                lon,
+                lat,
+                alt=alt,
+                not_visible_nan=not_visible_nan,
+                planetocentric=planetocentric,
+            )
         )
 
     def xy2km(

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -80,7 +80,7 @@ class TestBody(common_testing.BaseTestCase):
             self.assertIn(planetmapper.base.get_kernel_path(), e.message)
 
             # Ensure help message isn't added twice from nested decorated functions
-            self.assertEquals(
+            self.assertEqual(
                 e.message.count(planetmapper.base._SPICE_ERROR_HELP_TEXT), 1
             )
 
@@ -644,6 +644,33 @@ class TestBody(common_testing.BaseTestCase):
                     expected,
                     equal_nan=True,
                 )
+            for planetocentric in (False, True):
+                with self.subTest(
+                    lon=lon,
+                    lat=lat,
+                    alt=alt,
+                    not_visible_nan=not_visible_nan,
+                    planetocentric=planetocentric,
+                ):
+                    if planetocentric:
+                        lon_to_use, lat_to_use = self.body.graphic2centric_lonlat(
+                            lon, lat, alt=alt
+                        )
+                    else:
+                        lon_to_use, lat_to_use = lon, lat
+                    self.assertArraysClose(
+                        self.body._lonlat2obsvec(
+                            lon_to_use,
+                            lat_to_use,
+                            alt=alt,
+                            not_visible_nan=not_visible_nan,
+                            planetocentric=planetocentric,
+                        ),
+                        expected,
+                        equal_nan=True,
+                        atol=9e99 if alt > 1e6 else 1e-8,
+                        rtol=1e-4 if alt > 1e6 else 1e-5,
+                    )
 
     def test_lonlat2radec(self):
         pairs = [
@@ -664,6 +691,26 @@ class TestBody(common_testing.BaseTestCase):
                         equal_nan=True,
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat, planetocentric=planetocentric):
+                    if planetocentric:
+                        lon_to_use, lat_to_use = self.body.graphic2centric_lonlat(
+                            *lonlat
+                        )
+                    else:
+                        lon_to_use, lat_to_use = lonlat
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.lonlat2radec(
+                                lon_to_use,
+                                lat_to_use,
+                                not_visible_nan=False,
+                                planetocentric=planetocentric,
+                            ),
+                            radec,
+                            equal_nan=True,
+                        )
+                    )
 
         pairs_with_alts: list[
             tuple[tuple[float, float, float], tuple[float, float]]
@@ -680,6 +727,7 @@ class TestBody(common_testing.BaseTestCase):
                     expected,
                     equal_nan=True,
                 )
+
         # Test array broadcasting implementation
         self.assertArraysClose(
             self.body.lonlat2radec(
@@ -785,6 +833,34 @@ class TestBody(common_testing.BaseTestCase):
                     equal_nan=True,
                 )
 
+        with self.subTest('planetocentric'):
+            self.assertArraysClose(
+                self.body.lonlat2radec(
+                    [[0, 1, 100, 456.78, -42.42]],
+                    [[0, 5, 30, -45.6789, 90]],
+                    alt=123.44,
+                    planetocentric=True,
+                    not_visible_nan=False,
+                ),
+                (
+                    array(
+                        [
+                            [
+                                196.36982417,
+                                196.37008339,
+                                196.37670856,
+                                196.37344939,
+                                196.37390845,
+                            ]
+                        ]
+                    ),
+                    array(
+                        [[-5.56505968, -5.5646989, -5.565273, -5.57029209, -5.56152658]]
+                    ),
+                ),
+                equal_nan=True,
+            )
+
     def test_radec2lonlat(self):
         self.assertTrue(
             np.array_equal(
@@ -824,6 +900,21 @@ class TestBody(common_testing.BaseTestCase):
                             self.body.lonlat2radec(*lonlat), radec, equal_nan=True
                         )
                     )
+            for planetocentric in (False, True):
+                with self.subTest(radec, planetocentric=planetocentric):
+                    if planetocentric:
+                        lonlat_to_use = self.body.graphic2centric_lonlat(*lonlat)
+                    else:
+                        lonlat_to_use = lonlat
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.radec2lonlat(
+                                *radec, planetocentric=planetocentric
+                            ),
+                            lonlat_to_use,
+                            equal_nan=True,
+                        )
+                    )
 
         pairs_with_alts: list[
             tuple[tuple[float, float, float], tuple[float, float]]
@@ -847,6 +938,49 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertArraysClose(
                     self.body.radec2lonlat(ra, dec, alt=alt), expected, equal_nan=True
                 )
+
+        with self.subTest('planetocentric'):
+            self.assertArraysClose(
+                self.body.radec2lonlat(
+                    [
+                        [
+                            196.36982417,
+                            196.37008339,
+                            196.37670856,
+                            196.37344939,
+                            196.37390845,
+                        ]
+                    ],
+                    [[-5.56505968, -5.5646989, -5.565273, -5.57029209, -5.56152658]],
+                    alt=123.44,
+                    planetocentric=True,
+                ),
+                (
+                    array(
+                        [
+                            [
+                                -126.12884032,
+                                -127.36719725,
+                                137.03419591,
+                                130.7518092,
+                                -153.12075396,
+                            ]
+                        ]
+                    ),
+                    array(
+                        [
+                            [
+                                -4.81959108,
+                                0.13509603,
+                                28.23425081,
+                                -47.39154262,
+                                83.81857224,
+                            ]
+                        ]
+                    ),
+                ),
+                equal_nan=True,
+            )
 
     def test_lonlat2targvec(self):
         pairs = [
@@ -908,6 +1042,21 @@ class TestBody(common_testing.BaseTestCase):
                         self.body.targvec2lonlat(targvec), lonlat, equal_nan=True
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(targvec, planetocentric=planetocentric):
+                    if planetocentric:
+                        lonlat_to_use = self.body.graphic2centric_lonlat(*lonlat)
+                    else:
+                        lonlat_to_use = lonlat
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.targvec2lonlat(
+                                targvec, planetocentric=planetocentric
+                            ),
+                            lonlat_to_use,
+                            equal_nan=True,
+                        )
+                    )
         pairs_with_alts: list[tuple[tuple[np.ndarray, float], tuple[float, float]]] = [
             ((array([0, 0, 0]), 0), (0.0, 90.0)),
             ((array([1, 2, 3]), 0), (296.565051177078, 89.98665551067639)),
@@ -1041,6 +1190,49 @@ class TestBody(common_testing.BaseTestCase):
                 else:
                     with self.assertRaises(NotFoundError):
                         self.body.angular2lonlat(x, y, **kw, not_found_nan=False)
+            for planetocentric in (False, True):
+                with self.subTest(x=x, y=y, kw=kw, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertArraysClose(
+                        self.body.angular2lonlat(
+                            x, y, planetocentric=planetocentric, **kw
+                        ),
+                        lonlat_to_use,
+                        equal_nan=True,
+                        atol=1e-3,
+                    )
+                    if np.isfinite(lonlat[0]):
+                        self.assertArraysClose(
+                            self.body.lonlat2angular(
+                                *lonlat_to_use, planetocentric=planetocentric, **kw
+                            ),
+                            (x, y),
+                            atol=1e-4,
+                        )
+                        self.assertArraysClose(
+                            self.body.angular2lonlat(
+                                x,
+                                y,
+                                **kw,
+                                not_found_nan=False,
+                                planetocentric=planetocentric,
+                            ),
+                            lonlat_to_use,
+                            equal_nan=True,
+                        )
+                    else:
+                        with self.assertRaises(NotFoundError):
+                            self.body.angular2lonlat(
+                                x,
+                                y,
+                                **kw,
+                                not_found_nan=False,
+                                planetocentric=planetocentric,
+                            )
 
         inputs = [
             (np.nan, np.nan),
@@ -1204,6 +1396,28 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertTrue(
                     np.allclose(self.body.lonlat2km(*lonlat), km, atol=1e-3)
                 )
+            for planetocentric in (False, True):
+                with self.subTest(km, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.km2lonlat(*km, planetocentric=planetocentric),
+                            lonlat_to_use,
+                        )
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.lonlat2km(
+                                *lonlat_to_use, planetocentric=planetocentric
+                            ),
+                            km,
+                            atol=1e-3,
+                        )
+                    )
 
         self.assertTrue(
             np.array_equal(
@@ -1433,6 +1647,13 @@ class TestBody(common_testing.BaseTestCase):
                 ),
             ),
         )
+        self.assertArraysClose(
+            self.body.limb_lonlat(npts=3, planetocentric=True),
+            (
+                array([-153.1234683, 115.10057017, -61.34746043, -153.1234683]),
+                array([86.90599408, -29.95280995, -29.95280995, 86.90599408]),
+            ),
+        )
 
     def test_limb_radec_by_illumination(self):
         self.assertTrue(
@@ -1488,6 +1709,25 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertTrue(
                     np.allclose(dist, dist_expected, rtol=1e-5, equal_nan=True)
                 )
+            for planetocentric in (False, True):
+                with self.subTest(ra=ra, dec=dec, planetocentric=planetocentric):
+                    lon_to_use, lat_to_use = (
+                        self.body.graphic2centric_lonlat(lon_expected, lat_expected)
+                        if planetocentric
+                        else (lon_expected, lat_expected)
+                    )
+                    lon, lat, dist = self.body.limb_coordinates_from_radec(
+                        ra, dec, planetocentric=planetocentric
+                    )
+                    self.assertTrue(
+                        np.allclose(lon, lon_to_use, rtol=1e-5, equal_nan=True)
+                    )
+                    self.assertTrue(
+                        np.allclose(lat, lat_to_use, rtol=1e-5, equal_nan=True)
+                    )
+                    self.assertTrue(
+                        np.allclose(dist, dist_expected, rtol=1e-5, equal_nan=True)
+                    )
 
     def test_if_lonlat_visible(self):
         pairs: list[tuple[tuple[float, float], bool]] = [
@@ -1504,15 +1744,26 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertEqual(
                     self.body.test_if_lonlat_visible(*lonlat), visible, lonlat
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat=lonlat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertEqual(
+                        self.body.test_if_lonlat_visible(
+                            *lonlat_to_use, planetocentric=planetocentric
+                        ),
+                        visible,
+                    )
 
         pairs_with_alts: list[tuple[tuple[float, float, float], bool]] = [
             ((0, 0, 0), False),
             ((0, 0, 1000000.0), True),
-            ((0, 0, -1000000.0), True),
             ((153.1, -3.0, 0), True),
             ((153.1, -3.0, -1), False),
             ((153.1, -3.0, 1), True),
-            ((153.1, -3.0, nan), False),
             ((153.1, nan, 1), False),
         ]
         for (lon, lat, alt), visible in pairs_with_alts:
@@ -1520,6 +1771,21 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertEqual(
                     self.body.test_if_lonlat_visible(lon, lat, alt=alt), visible
                 )
+            for planetocentric in (False, True):
+                with self.subTest(
+                    lon=lon, lat=lat, alt=alt, planetocentric=planetocentric
+                ):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(lon, lat, alt=alt)
+                        if planetocentric
+                        else (lon, lat)
+                    )
+                    self.assertEqual(
+                        self.body.test_if_lonlat_visible(
+                            *lonlat_to_use, alt=alt, planetocentric=planetocentric
+                        ),
+                        visible,
+                    )
 
     def test_other_body_los_intercept(self):
         utc = '2005-01-01 04:00:00'
@@ -1579,6 +1845,22 @@ class TestBody(common_testing.BaseTestCase):
                         equal_nan=True,
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat=lonlat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.illumination_angles_from_lonlat(
+                                *lonlat_to_use, planetocentric=planetocentric
+                            ),
+                            angles,
+                            equal_nan=True,
+                        )
+                    )
 
     def test_azimuth_angle_from_lonlat(self):
         args: list[tuple[tuple[float, float], float]] = [
@@ -1598,6 +1880,22 @@ class TestBody(common_testing.BaseTestCase):
                         equal_nan=True,
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat=lonlat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.azimuth_angle_from_lonlat(
+                                *lonlat_to_use, planetocentric=planetocentric
+                            ),
+                            angle,
+                            equal_nan=True,
+                        )
+                    )
 
     def test_local_solar_time(self):
         args: list[tuple[float, float, str]] = [
@@ -1669,6 +1967,14 @@ class TestBody(common_testing.BaseTestCase):
             ),
             equal_nan=True,
         )
+        self.assertArraysClose(
+            self.body.terminator_lonlat(npts=5, only_visible=True, planetocentric=True),
+            self.body.graphic2centric_lonlat(
+                array([nan, nan, nan, 69.62871003, 74.2818866, nan]),
+                array([nan, nan, nan, -57.48337047, 20.36259847, nan]),
+            ),
+            equal_nan=True,
+        )
 
     def test_if_lonlat_illuminated(self):
         pairs: list[tuple[tuple[float, float], bool]] = [
@@ -1685,6 +1991,19 @@ class TestBody(common_testing.BaseTestCase):
                 self.assertEqual(
                     self.body.test_if_lonlat_illuminated(lon, lat), illuminated
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lon=lon, lat=lat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(lon, lat)
+                        if planetocentric
+                        else (lon, lat)
+                    )
+                    self.assertEqual(
+                        self.body.test_if_lonlat_illuminated(
+                            *lonlat_to_use, planetocentric=planetocentric
+                        ),
+                        illuminated,
+                    )
 
     def test_ring_plane_coordinates(self):
         args: list[tuple[tuple[float, float, bool], tuple[float, float, float]]] = [
@@ -2167,6 +2486,7 @@ class TestBody(common_testing.BaseTestCase):
     def test_radial_velocity_from_lonlat(self):
         args: list[tuple[tuple[float, float], float]] = [
             ((0, 0), -20.796924908179438),
+            ((45, 45), -17.75706386255955),
             ((np.nan, np.nan), np.nan),
             ((np.nan, 0), np.nan),
             ((0, np.nan), np.nan),
@@ -2181,10 +2501,27 @@ class TestBody(common_testing.BaseTestCase):
                         equal_nan=True,
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat=lonlat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.radial_velocity_from_lonlat(
+                                *lonlat_to_use, planetocentric=planetocentric
+                            ),
+                            x,
+                            equal_nan=True,
+                        )
+                    )
 
     def test_distance_from_lonalt(self):
         args: list[tuple[tuple[float, float], float]] = [
             ((0, 0), 819701772.0279644),
+            ((45, 45), 819656453.7301536),
             ((np.nan, np.nan), np.nan),
             ((np.nan, 0), np.nan),
             ((0, np.nan), np.nan),
@@ -2197,6 +2534,22 @@ class TestBody(common_testing.BaseTestCase):
                         self.body.distance_from_lonlat(*lonlat), x, equal_nan=True
                     )
                 )
+            for planetocentric in (False, True):
+                with self.subTest(lonlat=lonlat, planetocentric=planetocentric):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    self.assertTrue(
+                        np.allclose(
+                            self.body.distance_from_lonlat(
+                                *lonlat_to_use, planetocentric=planetocentric
+                            ),
+                            x,
+                            equal_nan=True,
+                        )
+                    )
 
     def test_graphic_centric_lonlat(self):
         pairs = [

--- a/tests/test_body.py
+++ b/tests/test_body.py
@@ -635,7 +635,11 @@ class TestBody(common_testing.BaseTestCase):
             ):
                 self.assertArraysClose(
                     self.body._lonlat2obsvec(
-                        lon, lat, alt=alt, not_visible_nan=not_visible_nan
+                        lon,
+                        lat,
+                        alt=alt,
+                        not_visible_nan=not_visible_nan,
+                        planetocentric=False,
                     ),
                     expected,
                     equal_nan=True,

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -347,6 +347,38 @@ class TestBodyXY(common_testing.BaseTestCase):
                     self.assertArraysClose(
                         body.angular2xy(*angular), xy, equal_nan=True, atol=1e-3
                     )
+                for planetocentric in (False, True):
+                    lonlat_to_use = (
+                        self.body.graphic2centric_lonlat(*lonlat)
+                        if planetocentric
+                        else lonlat
+                    )
+                    with self.subTest(
+                        xy=xy,
+                        body=body,
+                        func='xy2lonlat',
+                        planetocentric=planetocentric,
+                    ):
+                        self.assertArraysClose(
+                            body.xy2lonlat(*xy, planetocentric=planetocentric),
+                            lonlat_to_use,
+                            equal_nan=True,
+                        )
+                    with self.subTest(
+                        xy=xy,
+                        body=body,
+                        func='lonlat2xy',
+                        planetocentric=planetocentric,
+                    ):
+                        if not any(np.isnan(lonlat)):
+                            self.assertArraysClose(
+                                body.lonlat2xy(
+                                    *lonlat_to_use, planetocentric=planetocentric
+                                ),
+                                xy,
+                                equal_nan=True,
+                                atol=1e-3,
+                            )
 
         args = [
             (np.nan, np.nan),


### PR DESCRIPTION
Added a `planetocentric` parameter to most methods accepting or returning longitude/latitude coordinates. By default, these methods all deal with planetographic coordinates, but it is now possible to use planetocentric coordinates instead by specifying `planetocentric=True`. The default value of this new parameter is `False`, so the default behavior of using planetographic coordinates is unchanged.

```python
body.lonlat2radec(lon, lat)  # lon/lat are planetographic
body.lonlat2radec(lon, lat, planetocentric=True)  # lon/lat are planetocentric

body.radec2lonlat(ra, dec)  # returns planetographic lon/lat
body.radec2lonlat(ra, dec, planetocentric=True)  # returns planetocentric lon/lat
```

This new `planetocentric` parameter has been added to all methods using longitudes/latitudes, such as `radec2lonlat`, `lonlat2xy`, `terminator_lonlat`, `illumination_angles_from_lonlat` etc.

---

Internally, most of the logic is implemented in `_obsvec_norm2lonlat` and `_lonlat2obsvec`, with the public methods just needing the new keyword-only `planetocentric: bool = False` parameter adding then passing to the lower level methods. The docstrings for all relevant methods have been updated, as has the general documentation for the `lonlat` coordinate system, python examples page, and a new common issue entry.

Closes #534 

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.