### PR TITLE
Allow the use of distorted WCS, emitting a warning if there is any significant distortion 

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -4,3 +4,4 @@
 .. automodule:: planetmapper.exceptions
    :show-inheritance:
    :members:
+   :undoc-members:

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,0 +1,6 @@
+`planetmapper.exceptions`
+*************************
+
+.. automodule:: planetmapper.exceptions
+   :show-inheritance:
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ If you use PlanetMapper in your research, please cite the following paper:
 
    documentation
    base
+   exceptions
    gui
    cli
    utils

--- a/planetmapper/exceptions.py
+++ b/planetmapper/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Module containing any exceptions and warnings used by PlanetMapper.
+"""
+
+import os
+import warnings
+
+
+class PlanetmapperWarning(Warning):
+    """
+    Base class for all warnings raised by PlanetMapper.
+    """
+
+
+def warn(message: str, *, category: type[Warning] = PlanetmapperWarning) -> None:
+    """
+    Issue a warning, skipping stack frames within the planetmapper package. This means
+    that the warning will to be attributed to the relevant line of user code.
+    """
+    warnings.warn(
+        message,
+        category=category,
+        skip_file_prefixes=(os.path.dirname(__file__),),
+    )

--- a/planetmapper/exceptions.py
+++ b/planetmapper/exceptions.py
@@ -3,6 +3,7 @@ Module containing any exceptions and warnings used by PlanetMapper.
 """
 
 import os
+import sys
 import warnings
 
 
@@ -14,11 +15,21 @@ class PlanetmapperWarning(Warning):
 
 def warn(message: str, *, category: type[Warning] = PlanetmapperWarning) -> None:
     """
-    Issue a warning, skipping stack frames within the planetmapper package. This means
-    that the warning will to be attributed to the relevant line of user code.
+    Emit a warning with the given message.
     """
-    warnings.warn(
-        message,
-        category=category,
-        skip_file_prefixes=(os.path.dirname(__file__),),
-    )
+    if sys.version_info >= (3, 12):
+        # Skip stack frames within the planetmapper package, so that the warning is
+        # attributed to the relevant line of user code.
+        warnings.warn(
+            message,
+            category=category,
+            skip_file_prefixes=(os.path.dirname(__file__),),
+        )
+    else:
+        # skip_file_prefixes was added in Python 3.12, so for earlier versions, simply
+        # skip this warn() function instead.
+        warnings.warn(
+            message,
+            category=category,
+            stacklevel=2,
+        )

--- a/planetmapper/observation.py
+++ b/planetmapper/observation.py
@@ -19,6 +19,7 @@ from .body import (
     _cache_clearable_alt_dependent_result,
 )
 from .body_xy import BodyXY, MapKwargs, Unpack
+from .exceptions import warn
 from .progress import SaveMapProgressHookCLI, SaveNavProgressHookCLI, progress_decorator
 
 
@@ -435,6 +436,7 @@ class Observation(BodyXY):
         suppress_warnings: bool = False,
         validate: bool = True,
         use_header_offsets: bool = True,
+        distortion_warning_threshold: float | None = 0.25,
     ) -> tuple[float, float, float, float]:
         wcs = self._get_wcs_from_header(suppress_warnings=suppress_warnings)
 
@@ -450,8 +452,15 @@ class Observation(BodyXY):
                 raise ValueError(
                     'WCS axes are not RA/Dec coordinates'
                 )  # pragma: no cover
-            if wcs.has_distortion:
-                raise ValueError('WCS conversion contains distortion terms')
+
+            if distortion_warning_threshold is not None:
+                max_distortion, avg_distortion = (
+                    self._get_max_and_average_wcs_distortion(wcs)
+                )
+                if max_distortion > distortion_warning_threshold:
+                    warn(
+                        f'The WCS contains distortion of up to {max_distortion:.3f} pixels (average {avg_distortion:.3f} pixels), which is not accounted for by PlanetMapper.',
+                    )
 
         x0, y0 = wcs.world_to_pixel_values(self.target_ra, self.target_dec)
 
@@ -478,11 +487,24 @@ class Observation(BodyXY):
                 x0, y0, r0, rotation = body.get_disc_params()
         return x0, y0, r0, rotation
 
+    def _get_max_and_average_wcs_distortion(
+        self, wcs: astropy.wcs.WCS
+    ) -> tuple[float, float]:
+        if not wcs.has_distortion:
+            return 0.0, 0.0
+        x, y = np.meshgrid(
+            np.arange(0, self.data.shape[2]), np.arange(0, self.data.shape[1])
+        )
+        x_foc, y_foc = wcs.pix2foc(x, y, 0)
+        distortion_img = np.hypot(x_foc - x, y_foc - y)
+        return np.max(distortion_img), np.mean(distortion_img)
+
     def disc_from_wcs(
         self,
         suppress_warnings: bool = False,
         validate: bool = True,
         use_header_offsets: bool = True,
+        distortion_warning_threshold: float | None = 0.25,
     ) -> None:
         """
         Set disc parameters using WCS information in the observation's FITS header.
@@ -493,7 +515,11 @@ class Observation(BodyXY):
 
             There may be very slight differences between the coordinates converted
             directly from the WCS information and the coordinates converted by
-            PlanetMapper.
+            PlanetMapper depending on the location in the image the WCS uses as the
+            reference point. This is because PlanetMapper always uses the centre of the
+            target as the reference point for the tangent plane projection. Any
+            differences are usually incredibly small (e.g. < 0.1 pixels) so unlikely to
+            be significant for most applications.
 
         Args:
             suppress_warnings: Hide warnings produced by astropy when calculating WCS
@@ -501,16 +527,29 @@ class Observation(BodyXY):
             validate: Run checks to ensure the WCS conversion has appropriate RA/Dec
                 coordinate dimensions.
             use_header_offsets: If present, use the `HIERARCH NAV RA_OFFSET` and
-                `HIERARCH NAV DEC_OFFSET` values from the FITS headerr to adjust the
+                `HIERARCH NAV DEC_OFFSET` values from the FITS header to adjust the
                 target's disc location by the specified arcsecond offsets. If these
                 keywords are not present or `use_header_offsets` is `False`, no
                 adjustment is made.
+            distortion_warning_threshold: If the WCS contains distortion terms, a
+                :class:`planetmapper.exceptions.PlanetmapperWarning` will be emitted if
+                the maximum distortion at any point in the image exceeds this threshold
+                (in pixels). If this is `None`, no warning will be emitted regardless of
+                the distortion.
         Raises:
             ValueError: if no WCS information is found in the FITS header, or validation
                 fails.
+
+        .. versionchanged:: ?.?.?
+            Distorted WCS will now be accepted, and emit a warning if the maximum
+            distortion exceeds `distortion_warning_threshold`. Previously, a ValueError
+            was raised if any distortion terms were present in the WCS, however small.
         """
         x0, y0, r0, rotation = self._get_disc_params_from_wcs(
-            suppress_warnings, validate, use_header_offsets
+            suppress_warnings,
+            validate,
+            use_header_offsets,
+            distortion_warning_threshold=distortion_warning_threshold,
         )
         self.set_x0(x0)
         self.set_y0(y0)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import common_testing
+
+import planetmapper
+import planetmapper.exceptions
+
+
+class TestExceptions(common_testing.BaseTestCase):
+    def test_warn(self):
+        with self.assertWarns(planetmapper.exceptions.PlanetmapperWarning) as cm:
+            planetmapper.exceptions.warn('Test warning')
+        self.assertEqual(str(cm.warning), 'Test warning')
+
+        with self.assertWarns(UserWarning) as cm:
+            planetmapper.exceptions.warn('Test warning 2', category=UserWarning)
+        self.assertEqual(str(cm.warning), 'Test warning 2')

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1,4 +1,5 @@
 import fnmatch
+import inspect
 import os
 import unittest
 import warnings
@@ -14,6 +15,7 @@ from packaging import version
 
 import planetmapper
 import planetmapper.base
+import planetmapper.exceptions
 import planetmapper.progress
 from planetmapper import Observation
 
@@ -519,50 +521,52 @@ class TestObservation(common_testing.BaseTestCase):
         self.assertAlmostEqual(obs.get_rotation(), 4)
 
     def test_stuff_from_wcs(self):
-        with self.assertRaises(ValueError):
-            self.observation.disc_from_wcs(suppress_warnings=True)
-        with self.assertRaises(ValueError):
-            self.observation.position_from_wcs(suppress_warnings=True)
-        with self.assertRaises(ValueError):
-            self.observation.rotation_from_wcs(suppress_warnings=True)
-        with self.assertRaises(ValueError):
-            self.observation.plate_scale_from_wcs(suppress_warnings=True)
+        with self.subTest('no WCS'):
+            with self.assertRaises(ValueError):
+                self.observation.disc_from_wcs(suppress_warnings=True)
+            with self.assertRaises(ValueError):
+                self.observation.position_from_wcs(suppress_warnings=True)
+            with self.assertRaises(ValueError):
+                self.observation.rotation_from_wcs(suppress_warnings=True)
+            with self.assertRaises(ValueError):
+                self.observation.plate_scale_from_wcs(suppress_warnings=True)
 
-        x0 = 198.87871682168858
-        y0 = -31.89770255438151
-        r0 = 164.4473594677842
-        rotation = 260.32237572846986
+        with self.subTest('wcs.fits'):
+            x0 = 198.87871682168858
+            y0 = -31.89770255438151
+            r0 = 164.4473594677842
+            rotation = 260.32237572846986
 
-        path = os.path.join(common_testing.DATA_PATH, 'inputs', 'wcs.fits')
-        obs = Observation(path)
-        self.assertTrue(
-            np.allclose(obs.get_disc_params(), (x0, y0, r0, rotation), atol=0.2)
-        )
+            path = os.path.join(common_testing.DATA_PATH, 'inputs', 'wcs.fits')
+            obs = Observation(path)
+            self.assertTrue(
+                np.allclose(obs.get_disc_params(), (x0, y0, r0, rotation), atol=0.2)
+            )
 
-        obs.set_disc_params(0, 0, 1, 0)
-        self.assertEqual(obs.get_disc_params(), (0, 0, 1, 0))
+            obs.set_disc_params(0, 0, 1, 0)
+            self.assertEqual(obs.get_disc_params(), (0, 0, 1, 0))
 
-        obs.disc_from_wcs(suppress_warnings=True)
-        self.assertEqual(obs.get_disc_method(), 'wcs')
-        self.assertTrue(
-            np.allclose(obs.get_disc_params(), (x0, y0, r0, rotation), atol=0.2)
-        )
+            obs.disc_from_wcs(suppress_warnings=True)
+            self.assertEqual(obs.get_disc_method(), 'wcs')
+            self.assertTrue(
+                np.allclose(obs.get_disc_params(), (x0, y0, r0, rotation), atol=0.2)
+            )
 
-        obs.set_disc_params(0, 0, 1, 0)
-        obs.position_from_wcs(suppress_warnings=True)
-        self.assertEqual(obs.get_disc_method(), 'wcs_position')
-        self.assertAlmostEqual(obs.get_x0(), x0, delta=0.2)
-        self.assertAlmostEqual(obs.get_y0(), y0, delta=0.2)
+            obs.set_disc_params(0, 0, 1, 0)
+            obs.position_from_wcs(suppress_warnings=True)
+            self.assertEqual(obs.get_disc_method(), 'wcs_position')
+            self.assertAlmostEqual(obs.get_x0(), x0, delta=0.2)
+            self.assertAlmostEqual(obs.get_y0(), y0, delta=0.2)
 
-        obs.set_disc_params(0, 0, 1, 0)
-        obs.rotation_from_wcs(suppress_warnings=True)
-        self.assertEqual(obs.get_disc_method(), 'wcs_rotation')
-        self.assertAlmostEqual(obs.get_rotation(), rotation, delta=0.2)
+            obs.set_disc_params(0, 0, 1, 0)
+            obs.rotation_from_wcs(suppress_warnings=True)
+            self.assertEqual(obs.get_disc_method(), 'wcs_rotation')
+            self.assertAlmostEqual(obs.get_rotation(), rotation, delta=0.2)
 
-        obs.set_disc_params(0, 0, 1, 0)
-        obs.plate_scale_from_wcs(suppress_warnings=True)
-        self.assertEqual(obs.get_disc_method(), 'wcs_plate_scale')
-        self.assertAlmostEqual(obs.get_r0(), r0, delta=0.2)
+            obs.set_disc_params(0, 0, 1, 0)
+            obs.plate_scale_from_wcs(suppress_warnings=True)
+            self.assertEqual(obs.get_disc_method(), 'wcs_plate_scale')
+            self.assertAlmostEqual(obs.get_r0(), r0, delta=0.2)
 
         data = np.ones((5, 6, 7))
         header = fits.Header(
@@ -582,99 +586,130 @@ class TestObservation(common_testing.BaseTestCase):
             }
         )
         obs = Observation(data=data, header=header)
-        obs.disc_from_wcs(suppress_warnings=True)
-
-        x0_before = obs.get_x0()
-        y0_before = obs.get_y0()
-
-        data = np.ones((5, 6, 7))
-        h2 = header.copy()
-        h2['HIERARCH NAV RA_OFFSET'] = 1
-        h2['HIERARCH NAV DEC_OFFSET'] = -2.5
-        obs = Observation(data=data, header=h2)
-        obs.disc_from_wcs(suppress_warnings=True)
-        self.assertNotEqual(obs.get_x0(), x0_before)
-        self.assertNotEqual(obs.get_y0(), y0_before)
-
-        obs.add_arcsec_offset(-1, 2.5)  # undo the header offsets
-        self.assertAlmostEqual(obs.get_x0(), x0_before, delta=0.2)
-        self.assertAlmostEqual(obs.get_y0(), y0_before, delta=0.2)
-
-        obs.disc_from_wcs(suppress_warnings=True)
-        self.assertNotEqual(obs.get_x0(), x0_before)
-        self.assertNotEqual(obs.get_y0(), y0_before)
-
-        obs.disc_from_wcs(suppress_warnings=True, use_header_offsets=False)
-        self.assertAlmostEqual(obs.get_x0(), x0_before, delta=0.2)
-        self.assertAlmostEqual(obs.get_y0(), y0_before, delta=0.2)
-
-        h2 = header.copy()
-        h2['CTYPE1'] = 'DEC--TAN'
-        obs = Observation(data=data, header=h2)
-        with self.assertRaises(ValueError):
+        with self.subTest('header'):
             obs.disc_from_wcs(suppress_warnings=True)
 
-        h2 = header.copy()
-        h2['A_ORDER'] = 2
-        h2['B_ORDER'] = 2
-        for n in range(3):
-            for m in range(3):
-                h2[f'A_{n}_{m}'] = 0.1
-                h2[f'B_{n}_{m}'] = 0.2
-        obs = Observation(data=data, header=h2)
-        with self.assertRaises(ValueError):
+            x0_before = obs.get_x0()
+            y0_before = obs.get_y0()
+
+            data = np.ones((5, 6, 7))
+            h2 = header.copy()
+            h2['HIERARCH NAV RA_OFFSET'] = 1
+            h2['HIERARCH NAV DEC_OFFSET'] = -2.5
+            obs = Observation(data=data, header=h2)
             obs.disc_from_wcs(suppress_warnings=True)
-        obs.disc_from_wcs(validate=False, suppress_warnings=True)
+            self.assertNotEqual(obs.get_x0(), x0_before)
+            self.assertNotEqual(obs.get_y0(), y0_before)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('error')
-            obs.position_from_wcs(validate=False, suppress_warnings=True)
+            obs.add_arcsec_offset(-1, 2.5)  # undo the header offsets
+            self.assertAlmostEqual(obs.get_x0(), x0_before, delta=0.2)
+            self.assertAlmostEqual(obs.get_y0(), y0_before, delta=0.2)
 
-        # Test invalid CUNIT3 is ignored properly
-        # Header baased off real MUSE data file
-        header = fits.Header(
-            {
-                'SIMPLE': True,
-                'OBJECT': 'jupiter',
-                'DATE-OBS': '2005-01-01',
-                'BITPIX': -32,
-                'NAXIS': 3,
-                'NAXIS1': 91,
-                'NAXIS2': 91,
-                'NAXIS3': 3681,
-                'WCSAXES': 3,
-                'CRPIX1': 64.135608107686,
-                'CRPIX2': 27.282318423363,
-                'CUNIT1': 'deg',
-                'CUNIT2': 'deg',
-                'CTYPE1': 'RA---TAN',
-                'CTYPE2': 'DEC--TAN',
-                'CRVAL1': 255.071254,
-                'CRVAL2': -22.20829,
-                'CD1_1': -7.0388888888889e-06,
-                'CD1_2': 0.0,
-                'CD2_1': 0.0,
-                'CD2_2': 7.0388888888889e-06,
-                'CRVAL3': 0.474978369140625,
-                'CRPIX3': 1.0,
-                'CUNIT3': 'Microns',
-                'CTYPE3': 'WAVE',
-                'CD3_3': 0.000124999999999986,
-                'CD1_3': 0.0,
-                'CD2_3': 0.0,
-                'CD3_1': 0.0,
-                'CD3_2': 0.0,
-                'BUNIT': '10**-20 Angstrom-1 cm-2 erg s-1',
-                'RADECSYS': 'FK5',
-            }
-        )
-        obs = Observation(data=data, header=header)
-        obs._get_disc_params_from_wcs(suppress_warnings=True)
+            obs.disc_from_wcs(suppress_warnings=True)
+            self.assertNotEqual(obs.get_x0(), x0_before)
+            self.assertNotEqual(obs.get_y0(), y0_before)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('always')
-            with self.assertWarns(AstropyWarning):
-                obs._get_disc_params_from_wcs(validate=False, suppress_warnings=False)
+            obs.disc_from_wcs(suppress_warnings=True, use_header_offsets=False)
+            self.assertAlmostEqual(obs.get_x0(), x0_before, delta=0.2)
+            self.assertAlmostEqual(obs.get_y0(), y0_before, delta=0.2)
+
+        with self.subTest('DEC--TAN'):
+            h2 = header.copy()
+            h2['CTYPE1'] = 'DEC--TAN'
+            obs = Observation(data=data, header=h2)
+            with self.assertRaises(ValueError):
+                obs.disc_from_wcs(suppress_warnings=True)
+
+        with self.subTest('distortion'):
+            h2 = header.copy()
+            h2['A_ORDER'] = 2
+            h2['B_ORDER'] = 2
+            for n in range(3):
+                for m in range(3):
+                    h2[f'A_{n}_{m}'] = 0.1
+                    h2[f'B_{n}_{m}'] = 0.2
+            with warnings.catch_warnings():
+                warnings.simplefilter(
+                    'default', category=planetmapper.exceptions.PlanetmapperWarning
+                )
+                with self.assertWarns(
+                    planetmapper.exceptions.PlanetmapperWarning
+                ) as cm:
+                    obs = Observation(data=data, header=h2)
+                self.assertEqual(
+                    str(cm.warning),
+                    'The WCS contains distortion of up to 23.032 pixels (average 8.087 pixels), which is not accounted for by PlanetMapper.',
+                )
+            with self.assertWarns(planetmapper.exceptions.PlanetmapperWarning) as cm:
+                obs.disc_from_wcs(suppress_warnings=True, use_header_offsets=False)
+            self.assertEqual(
+                str(cm.warning),
+                'The WCS contains distortion of up to 23.032 pixels (average 8.087 pixels), which is not accounted for by PlanetMapper.',
+            )
+            obs.disc_from_wcs(validate=False, suppress_warnings=True)
+            obs.disc_from_wcs(suppress_warnings=True, distortion_warning_threshold=24.0)
+            obs.disc_from_wcs(suppress_warnings=True, distortion_warning_threshold=None)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter('error')
+                obs.position_from_wcs(validate=False, suppress_warnings=True)
+
+        with self.subTest('consistent signature'):
+            # Ensure the defaults are consistent (then e.g. rotation_from_wcs will be
+            # consistent as it works with _get_disc_params_from_wcs)
+            self.assertEqual(
+                inspect.signature(obs.disc_from_wcs).parameters,
+                inspect.signature(obs._get_disc_params_from_wcs).parameters,
+            )
+
+        with self.subTest('invalid CUNIT3'):
+            # Test invalid CUNIT3 is ignored properly
+            # Header baased off real MUSE data file
+            header = fits.Header(
+                {
+                    'SIMPLE': True,
+                    'OBJECT': 'jupiter',
+                    'DATE-OBS': '2005-01-01',
+                    'BITPIX': -32,
+                    'NAXIS': 3,
+                    'NAXIS1': 91,
+                    'NAXIS2': 91,
+                    'NAXIS3': 3681,
+                    'WCSAXES': 3,
+                    'CRPIX1': 64.135608107686,
+                    'CRPIX2': 27.282318423363,
+                    'CUNIT1': 'deg',
+                    'CUNIT2': 'deg',
+                    'CTYPE1': 'RA---TAN',
+                    'CTYPE2': 'DEC--TAN',
+                    'CRVAL1': 255.071254,
+                    'CRVAL2': -22.20829,
+                    'CD1_1': -7.0388888888889e-06,
+                    'CD1_2': 0.0,
+                    'CD2_1': 0.0,
+                    'CD2_2': 7.0388888888889e-06,
+                    'CRVAL3': 0.474978369140625,
+                    'CRPIX3': 1.0,
+                    'CUNIT3': 'Microns',
+                    'CTYPE3': 'WAVE',
+                    'CD3_3': 0.000124999999999986,
+                    'CD1_3': 0.0,
+                    'CD2_3': 0.0,
+                    'CD3_1': 0.0,
+                    'CD3_2': 0.0,
+                    'BUNIT': '10**-20 Angstrom-1 cm-2 erg s-1',
+                    'RADECSYS': 'FK5',
+                }
+            )
+            obs = Observation(data=data, header=header)
+            obs._get_disc_params_from_wcs(suppress_warnings=True)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter('always')
+                with self.assertWarns(AstropyWarning):
+                    obs._get_disc_params_from_wcs(
+                        validate=False, suppress_warnings=False
+                    )
 
     def test_wcs_offset(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
PlanetMapper can now use WCS information that contains distortion terms when setting disc parameters.

Previously, if there were any distortion terms present in the WCS (however small), `disc_from_wcs` would raise a `ValueError` preventing the use of any of the WCS information. This meant that for observations with some distortion, the disc parameters were initialised with a centred disc, providing no useful starting parameters for the user. Now, the disc parameters will be initialised using the WCS, providing _much_ better starting values.

If the distortion at any pixel is larger than `distortion_warning_threshold`, a warning will be emitted, informing the user of the distortion and its size (max value, and average over the image). The user can then decide how to proceed for their specific dataset, but the initial values will generally be much more useful than the alternative from `centre_disc`.

This is useful for observations such as JWST/NIRCam images, which have very small distortion (~0.1px at the extremes in the corner of the images, ~0 in the middle). Now, PlanetMapper will initialise observations (and the GUI) with a much more useful disc:

Previous default disc, not using any WCS information due to very small distortion terms:
<img width="446" height="496" alt="image" src="https://github.com/user-attachments/assets/b75414be-cfe3-4884-82f6-b099a32dbb10" />

New default disc, using the WCS information from the FITS header:
<img width="446" height="496" alt="image" src="https://github.com/user-attachments/assets/147752ac-8e5a-48d3-b55b-49fba2f059e1" />

---

This is implemented by calculating `wcs.pix2foc` at each location in the image, to calculate the distance between the pixels and distorted pixel locations across the image. We then conservatively use the largest value of this distortion image as the threshold for warning the user (and also report the average distortion as part of the warning message). 

As part of this, added a new planetmapper.exceptions module to standardise how we raise warnings, using a consistent `PlanetmapperWarning` class, and a `warn` function to set the stack location to be in the user code. This can then be used in #484.

Closes #537

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.