### PR TITLE
Freeze the matplotlib transforms when calling `plot_wireframe_xy` by default

### DIFF
--- a/planetmapper/body_xy.py
+++ b/planetmapper/body_xy.py
@@ -1637,6 +1637,7 @@ class BodyXY(Body):
         add_axis_labels: bool | None = None,
         aspect_adjustable: Literal['box', 'datalim'] | None = 'box',
         show: bool = False,
+        freeze_transform: bool = True,
         **wireframe_kwargs: Unpack[WireframeKwargs],
     ) -> Axes:
         """
@@ -1644,18 +1645,37 @@ class BodyXY(Body):
         coordinates. See :func:`Body.plot_wireframe_radec` for details of accepted
         arguments.
 
+        Args:
+            freeze_transform: If `True` (the default), then the wireframe is 'frozen'
+                with the disc parameters at the time that `plot_wireframe_xy` is called.
+                If `False`, then the wireframe will update if the disc parameters are
+                adjusted after `plot_wireframe_xy` is called - this is mainly useful
+                when creating interactive plots. See
+                :func:`matplotlib_xy2radec_transform` for more details.
+            **kwargs: See :func:`Body.plot_wireframe_radec` for details of other
+                arguments.
+
         Returns:
             The axis containing the plotted wireframe.
+
+        .. versionchanged:: ?.?.?
+            Added `freeze_transform` to freeze the wireframe in place by default when
+            plotting. The previous behaviour of an auto-updating wireframe can be
+            achieved by setting `freeze_transform=False`.
         """
         if add_axis_labels is None:
             add_axis_labels = scale_factor is None
+
+        transform = self._get_matplotlib_angular_fixed2xy_transform()
+        if freeze_transform:
+            transform = transform.frozen()
 
         # Use combo of corodinate_func and matplotlib transform so that the plot can be
         # updated with new disc parameters without having to replot the entire thing
         ax = self._plot_wireframe(
             coordinate_func=self.radec2angular,
             scale_factor=scale_factor,
-            transform=self._get_matplotlib_angular_fixed2xy_transform(),
+            transform=transform,
             aspect_adjustable=aspect_adjustable,
             ax=ax,
             **wireframe_kwargs,

--- a/tests/test_body_xy.py
+++ b/tests/test_body_xy.py
@@ -1037,6 +1037,42 @@ class TestBodyXY(common_testing.BaseTestCase):
         )
         plt.close(fig)
 
+        with self.subTest('frozen transforms'):
+
+            def are_transforms_equal(ax1, ax2):
+                t1 = ax1.get_lines()[0].get_transform() - ax1.transData
+                t2 = ax2.get_lines()[0].get_transform() - ax2.transData
+                return t1 == t2
+
+            self.body.set_disc_params(7.5, 5.0, 4.5, 0.0)
+            fig1, ax1 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax1)
+            fig2, ax2 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax2)
+            self.assertTrue(are_transforms_equal(ax1, ax2))
+            plt.close(fig1)
+            plt.close(fig2)
+
+            self.body.set_disc_params(7.5, 5.0, 4.5, 0.0)
+            fig1, ax1 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax1)
+            self.body.adjust_disc_params(dx=1, dy=2, dr=3, drotation=4)
+            fig2, ax2 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax2)
+            self.assertFalse(are_transforms_equal(ax1, ax2))
+            plt.close(fig1)
+            plt.close(fig2)
+
+            self.body.set_disc_params(7.5, 5.0, 4.5, 0.0)
+            fig1, ax1 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax1, freeze_transform=False)
+            self.body.adjust_disc_params(dx=1, dy=2, dr=3, drotation=4)
+            fig2, ax2 = plt.subplots()
+            self.body.plot_wireframe_xy(ax=ax2)
+            self.assertTrue(are_transforms_equal(ax1, ax2))
+            plt.close(fig1)
+            plt.close(fig2)
+
     def test_get_wireframe_overlay(self):
         img = self.body.get_wireframe_overlay_img(output_size=100)
         self.assertEqual(max(img.shape), 100)


### PR DESCRIPTION
Add new argument `freeze_transform=True` to control freezing of mutable matplotlib transform when calling `BodyXY.plot_wireframe_xy`.

By default, the plotted wireframe is now frozen with the disc parameters present at the time `plot_wireframe_xy` is called. Previously, the wireframe would be updated if the disc parameters were adjusted after calling `plot_wireframe_xy` but before e.g. `plt.show`. This behaviour was useful for making interactive plots, but could be very confusing if used in normal scripts, and inconsistent with manually marking locations with e.g. `lonlat2xy`.

The previous behaviour of an auto-updating wireframe can be achieved by passing `plot_wireframe_xy(freeze_transform=False)`. 

New default behaviour - the wireframes keep the disc parameters the observation had at the moment they were plotted: 
<img width="985" height="514" alt="image" src="https://github.com/user-attachments/assets/b8a2e051-43b9-4aee-b3b1-9575b6cd9957" />

Behaviour with `plot_wireframe_xy(..., freeze_transform=False)` - both wireframes are identical, even though the first wireframe was plotted when the observation had different disc parameters. This was the previous behaviour:
<img width="985" height="514" alt="image" src="https://github.com/user-attachments/assets/b54230cb-dbca-4705-94ce-d9c9edcb0c14" />

```python
fig, axs = plt.subplots(nrows=1, ncols=2)
observation.plot_wireframe_xy(ax=axs[0]) # Plot wireframe 1
observation.set_disc_params(...) # Adjust the disc parameters between the plot_wireframe_xy calls
observation.plot_wireframe_xy(ax=axs[1]) # Plot wireframe 2
plt.show()
```

---

Closes #580

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.