### PR TITLE
Ensure the GUI's open dialog box always shows a human readable date, even when using MJD values from a FITS header

### DIFF
--- a/planetmapper/base.py
+++ b/planetmapper/base.py
@@ -805,19 +805,7 @@ class BodyBase(SpiceBase):
         super().__init__(**kwargs)
 
         # Process inputs
-        if isinstance(utc, (float, int, numbers.Number)):
-            # Include a check for numbers.Number to allow other numeric types
-            utc = self.mjd2dtm(utc)
-        if utc is None:
-            utc = datetime.datetime.now(datetime.timezone.utc)
-        if isinstance(utc, datetime.datetime):
-            # convert input datetime to UTC, then to a string compatible with spice
-            if utc.tzinfo is None:
-                # Default to UTC if no timezone is specified
-                utc = utc.replace(tzinfo=datetime.timezone.utc)
-            # Standardise to UTC
-            utc = utc.astimezone(tz=datetime.timezone.utc)
-            utc = utc.strftime(self._DEFAULT_DTM_FORMAT_STRING)
+        utc = self._standardise_utc_to_string(utc)
 
         self.target = self.standardise_body_name(target)
         self.observer = self.standardise_body_name(observer)
@@ -849,6 +837,28 @@ class BodyBase(SpiceBase):
         # cast() calls are only here to make type checking play nicely with spice.spkezr
         self.target_distance = self.target_light_time * self.speed_of_light()
         self.target_ra, self.target_dec = self._obsvec2radec(self._target_obsvec)
+
+    @classmethod
+    def _standardise_utc_to_string(
+        cls, utc: str | datetime.datetime | float | None
+    ) -> str:
+        """
+        Standardise a UTC input into a string
+        """
+        if isinstance(utc, (float, int, numbers.Number)):
+            # Include a check for numbers.Number to allow other numeric types
+            utc = cls.mjd2dtm(utc)
+        if utc is None:
+            utc = datetime.datetime.now(datetime.timezone.utc)
+        if isinstance(utc, datetime.datetime):
+            # convert input datetime to UTC, then to a string compatible with spice
+            if utc.tzinfo is None:
+                # Default to UTC if no timezone is specified
+                utc = utc.replace(tzinfo=datetime.timezone.utc)
+            # Standardise to UTC
+            utc = utc.astimezone(tz=datetime.timezone.utc)
+            utc = utc.strftime(cls._DEFAULT_DTM_FORMAT_STRING)
+        return utc
 
     def __repr__(self) -> str:
         return self._generate_repr()

--- a/planetmapper/gui.py
+++ b/planetmapper/gui.py
@@ -2692,6 +2692,8 @@ class OpenObservation(Popup):
             except FileNotFoundError:
                 pass
         for k, v in kwargs.items():
+            if k == 'utc':
+                v = Observation._standardise_utc_to_string(v)
             try:
                 if v:
                     self.stringvars[k].set(str(v))

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,5 +1,7 @@
 import datetime
+import decimal
 import glob
+import numbers
 import os
 import unittest
 from pathlib import Path
@@ -698,6 +700,93 @@ class TestBodyBase(common_testing.BaseTestCase):
             )
             obj = BodyBase(utc=None, **kw)
             self.assertEqual(obj.utc, '2005-01-01T12:30:00.000000')
+
+    def test_standardise_utc_to_string(self):
+
+        equivalent_utcs = [
+            datetime.datetime(2005, 1, 1, 12),
+            datetime.datetime(
+                2005, 1, 1, 15, tzinfo=datetime.timezone(datetime.timedelta(hours=3))
+            ),
+            53371.5,
+            np.float64(53371.5),
+            decimal.Decimal('53371.5'),
+            '2005-01-01T12:00',
+            '2005-01-01T12:00:00',
+            '2005-01-01T12:00:00.000',
+            '2005-01-01T12:00:00.000000',
+            '2005-01-01T12:00:00.000000Z',
+            '2005 January 1 12:00',
+            '2005-01-01 12:00 UTC',
+            '2005-01-01 11:00 UTC-1',
+            '2005-01-01 23:12 UTC+11:12',
+        ]
+        for utc_in in equivalent_utcs:
+            with self.subTest(utc=utc_in):
+                utc_out = BodyBase._standardise_utc_to_string(utc_in)
+                self.assertIsInstance(utc_out, str)
+                if isinstance(utc_in, str):
+                    self.assertEqual(utc_in, utc_out)
+                else:
+                    self.assertEqual(utc_out, '2005-01-01T12:00:00.000000')
+
+                # Make sure second pass is a no-op
+                self.assertEqual(
+                    BodyBase._standardise_utc_to_string(utc_in),
+                    BodyBase._standardise_utc_to_string(utc_out),
+                )
+
+        equivalent_utcs = [
+            datetime.datetime(2005, 1, 1),
+            datetime.datetime(
+                2005, 1, 1, 3, tzinfo=datetime.timezone(datetime.timedelta(hours=3))
+            ),
+            53371,
+            53371.0,
+            np.float64(53371),
+            np.int64(53371),
+            decimal.Decimal('53371'),
+            decimal.Decimal('53371.0'),
+            '2005 January 1',
+            '2005-01-01',
+            '2005-01-01T00:00',
+            '2005-01-01T00:00:00',
+            '2005-01-01T00:00:00.000',
+            '2005-01-01T00:00:00.000000',
+            '2005-01-01T00:00:00.000000Z',
+            '2005 January 1 00:00',
+            '2005-01-01 00:00 UTC',
+            '2004-12-31 25:00 UTC-1',
+            '2005-01-01 11:12 UTC+11:12',
+        ]
+        for utc_in in equivalent_utcs:
+            with self.subTest('midnight', utc=utc_in):
+                utc_out = BodyBase._standardise_utc_to_string(utc_in)
+                self.assertIsInstance(utc_out, str)
+                if isinstance(utc_in, str):
+                    self.assertEqual(utc_in, utc_out)
+                else:
+                    self.assertEqual(utc_out, '2005-01-01T00:00:00.000000')
+
+                # Make sure second pass is a no-op
+                self.assertEqual(
+                    BodyBase._standardise_utc_to_string(utc_in),
+                    BodyBase._standardise_utc_to_string(utc_out),
+                )
+
+        with self.subTest(utc=None):
+
+            class CustomDateTime(datetime.datetime):
+                pass
+
+            with patch('planetmapper.base.datetime', new=datetime) as mock_datetime:
+                mock_datetime.datetime = CustomDateTime
+                mock_datetime.datetime.now = MagicMock()
+                mock_datetime.datetime.now.return_value = datetime.datetime(
+                    2005, 1, 1, 12
+                )
+                utc_out = BodyBase._standardise_utc_to_string(None)
+                self.assertEqual(utc_out, '2005-01-01T12:00:00.000000')
 
     def test_get_default_init_kwargs(self):
         self._test_get_default_init_kwargs(


### PR DESCRIPTION
When opening a FITS file with the GUI's open dialog, the target, date and observer fields are auto-populated (if possible) using information from the FITS header. Previously, this meant that if the header contained dates in MJD format, the date field would show the date as a numeric value. This worked completely fine, but made it difficult to double check or understand the auto-populated value.

Therefore, this update will automatically convert auto-populated MJD values (e.g. `61043.93858073495` to a human readable date (e.g. `2026-01-03T22:31:33.375500`), making it much easier for the user to understand what the value means.

This has no functional effect, but just makes things easier to use.

---

This is implemented by re-using the same code that is used to convert a MJD to a SPICE-compatible date. The date standardisation code has been extracted from `BodyBase.__init__` and now lives in the classmethod `BodyBase._standardise_utc_to_string`, where it can easily be re-used by other parts of the code as necesary. Extra unit tests have been added to ensure this conversion works as expected across different inputs, and provides a stable output.

Closes #585

---

### Pull request checklist
- [x] Add a clear description of the change
- [x] Add any new tests needed
- [x] Run spell check on new text visible to user (documentation, GUI etc.)
- [x] Check any changes to `requirements.txt` are reflected in `setup.py` and [conda-forge feedstock](https://github.com/conda-forge/planetmapper-feedstock)
- [x] Check code passes CI checks (run `run_ci.sh` or check GitHub Actions)

See [CONTRIBUTING.md](https://github.com/ortk95/planetmapper/blob/main/CONTRIBUTING.md) for more details.